### PR TITLE
In tests address warnings

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -18,7 +18,7 @@ categorize_matching_certainity <- function(x, ...) {
 
 add_avg_matching_certainty <- function(data, col) {
   data |>
-    rename(matching_certainty = .data[[col]]) |>
+    rename(matching_certainty = all_of(col)) |>
     mutate(matching_certainty_num = categorize_matching_certainity(.data$matching_certainty)) |>
     mutate(avg_matching_certainty_num = mean(.data$matching_certainty_num, na.rm = TRUE), .by = c("companies_id")) |>
     mutate(avg_matching_certainty = categorize_avg_matching_certainity(.data$avg_matching_certainty_num))


### PR DESCRIPTION
Closes #30 

This PR silences test warnings by following the warning advice: 

```r
i Please use `all_of(var)` (or `any_of(var)`) instead of `.data[[var]]`
```

For us this means replacing `.data[[col]]` with `any_of(col)`.
