### PR TITLE
Test `*risk_category` in `sector_profile()` at product level

### DIFF
--- a/tests/testthat/test-prepare_istr_product.R
+++ b/tests/testthat/test-prepare_istr_product.R
@@ -1,4 +1,4 @@
-# FIME: Add meaningful test
+# FIXME: Add meaningful test
 
 test_that("handles tiltIndicator output", {
   product <- unnest_product(toy_sector_profile_upstream_output())

--- a/tests/testthat/test-prepare_istr_product.R
+++ b/tests/testthat/test-prepare_istr_product.R
@@ -1,4 +1,4 @@
-# FIXME: Add meaningful test
+# FIME: Add meaningful test
 
 test_that("handles tiltIndicator output", {
   product <- unnest_product(toy_sector_profile_upstream_output())

--- a/tests/testthat/test-prepare_pstr_company.R
+++ b/tests/testthat/test-prepare_pstr_company.R
@@ -35,8 +35,12 @@ test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", 
   product_empty[1, "companies_id"] <- "a"
   product_empty[1, "risk_category"] <- NA_character_
 
-  # FIXME: Export a fake from tiltIndicator
-  company_empty <- tiltIndicator:::empty_company_output_from("a")
+  company_empty <- tibble(
+    companies_id = "a",
+    grouped_by = NA_character_,
+    risk_category = NA_character_,
+    value = NA_real_
+  )
 
   result <- prepare_pstr_company(
     company_empty,

--- a/tests/testthat/test-prepare_pstr_company.R
+++ b/tests/testthat/test-prepare_pstr_company.R
@@ -29,3 +29,26 @@ test_that("handles tiltIndicator output", {
     )
   )
 })
+
+test_that("risk_category colummn should not have more than one NA for no result companies", {
+  product_empty <- unnest_product(toy_sector_profile_output())[1, ]
+  product_empty[1, "companies_id"] <- "a"
+  product_empty[1, "risk_category"] <- NA_character_
+
+  # FIXME: Export a fake from tiltIndicator
+  company_empty <- tiltIndicator:::empty_company_output_from("a")
+
+  result <- prepare_pstr_company(
+    company_empty,
+    product_empty,
+    ep_companies,
+    ecoinvent_activities,
+    small_matches_mapper
+  )
+  out <- result |>
+    filter(is.na(get_column(result, "risk_category"))) |>
+    group_by(companies_id) |>
+    summarise(count = n())
+
+  expect_true(unique(out$count) <= 1)
+})

--- a/tests/testthat/test-prepare_pstr_company.R
+++ b/tests/testthat/test-prepare_pstr_company.R
@@ -30,7 +30,7 @@ test_that("handles tiltIndicator output", {
   )
 })
 
-test_that("risk_category colummn should not have more than one NA for no result companies", {
+test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", {
   product_empty <- unnest_product(toy_sector_profile_output())[1, ]
   product_empty[1, "companies_id"] <- "a"
   product_empty[1, "risk_category"] <- NA_character_

--- a/tests/testthat/test-prepare_pstr_company.R
+++ b/tests/testthat/test-prepare_pstr_company.R
@@ -54,5 +54,5 @@ test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", 
     group_by(companies_id) |>
     summarise(count = n())
 
-  expect_true(unique(out$count) <= 1)
+  expect_lte(unique(out$count), 1)
 })

--- a/tests/testthat/test-prepare_pstr_product.R
+++ b/tests/testthat/test-prepare_pstr_product.R
@@ -27,7 +27,7 @@ test_that("handles tiltIndicator output", {
   )
 })
 
-test_that("risk_category colummn should not have more than one NA for no result companies", {
+test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", {
   product_empty <- unnest_product(toy_sector_profile_output())[1, ]
   product_empty[1, "companies_id"] <- "a"
   product_empty[1, "risk_category"] <- NA_character_

--- a/tests/testthat/test-prepare_pstr_product.R
+++ b/tests/testthat/test-prepare_pstr_product.R
@@ -33,6 +33,5 @@ test_that("risk_category colummn should not have more than one NA for no result 
     filter(is.na(get_column(result, "risk_category"))) |>
     group_by(companies_id) |>
     summarise(count = n())
-
-  expect_equal(unique(out$count), 1L)
+  expect_true(unique(out$count) <= 1)
 })

--- a/tests/testthat/test-prepare_pstr_product.R
+++ b/tests/testthat/test-prepare_pstr_product.R
@@ -26,3 +26,13 @@ test_that("handles tiltIndicator output", {
     )
   )
 })
+
+test_that("risk_category colummn should not have more than one NA for no result companies", {
+  result <- prepare_pstr_product(pstr_product, ep_companies, ecoinvent_activities, small_matches_mapper)
+  out <- result |>
+    filter(is.na(get_column(result, "risk_category"))) |>
+    group_by(companies_id) |>
+    summarise(count = n())
+
+  expect_equal(unique(out$count), 1L)
+})

--- a/tests/testthat/test-prepare_pstr_product.R
+++ b/tests/testthat/test-prepare_pstr_product.R
@@ -28,10 +28,20 @@ test_that("handles tiltIndicator output", {
 })
 
 test_that("risk_category colummn should not have more than one NA for no result companies", {
-  result <- prepare_pstr_product(pstr_product, ep_companies, ecoinvent_activities, small_matches_mapper)
+  product_empty <- unnest_product(toy_sector_profile_output())[1, ]
+  product_empty[1, "companies_id"] <- "a"
+  product_empty[1, "risk_category"] <- NA_character_
+
+  result <- prepare_pstr_product(
+    product_empty,
+    ep_companies,
+    ecoinvent_activities,
+    small_matches_mapper
+  )
   out <- result |>
     filter(is.na(get_column(result, "risk_category"))) |>
     group_by(companies_id) |>
     summarise(count = n())
+
   expect_true(unique(out$count) <= 1)
 })

--- a/tests/testthat/test-prepare_pstr_product.R
+++ b/tests/testthat/test-prepare_pstr_product.R
@@ -43,5 +43,5 @@ test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", 
     group_by(companies_id) |>
     summarise(count = n())
 
-  expect_true(unique(out$count) <= 1)
+  expect_lte(unique(out$count), 1)
 })


### PR DESCRIPTION
(Note "sector profile" is the new name for "pstr".)

In an earlier version of the package I see a test for the internal function `prepare_inter_pstr_product()`:

```r
test_that("risk_category colummn should not have more than one NA for no result companies", {
  out <- prepare_inter_pstr_product(pstr_product, ep_companies, ecoinvent_activities, matches_mapper) |>
    filter(is.na(risk_category)) |>
    group_by(companies_id) |>
    summarise(count = n())
  
  expect_equal(unique(out$count), 1L)
})
```

This PR restores that test but via the public interface: `prepare_pstr_product()`. My inspection suggests that `prepare_pstr_product()` does nothing with `NA`s so they should be exactly as they were in the intermediate state created by the internal `prepare_inter_pstr_product()`.

Note I use a small version of matches mapper to reduce computation time. I see the large and small versions of that file both have only 1 NA in the output of `prepare_*pstr_product()`.

@kalashsinghal please revew. As the author of the original test you know best why that test is important and to understand if it makes sense to test this via `prepare_pstr_product()` rather than via the internal `prepare_inter_pstr_product()`.