### PR TITLE
Deprecate the old API

### DIFF
--- a/R/prepare_ictr_company.R
+++ b/R/prepare_ictr_company.R
@@ -16,7 +16,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_emissions_upstream`
 prepare_ictr_company <- function(ictr_comp, ictr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   ictr_prod <- sanitize_isic(ictr_prod)
 

--- a/R/prepare_ictr_company.R
+++ b/R/prepare_ictr_company.R
@@ -1,5 +1,8 @@
 #' Creates final output of ictr company level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param ictr_prod A dataframe like [ictr_product]
@@ -11,17 +14,9 @@
 #' @return A dataframe that prepares the final output of ictr_company
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' prepare_ictr_company(
-#'   ictr_company |> head(3),
-#'   ictr_product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   ecoinvent_inputs |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_ictr_company <- function(ictr_comp, ictr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   ictr_prod <- sanitize_isic(ictr_prod)
 

--- a/R/prepare_ictr_company.R
+++ b/R/prepare_ictr_company.R
@@ -16,7 +16,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_emissions_upstream`
+#' # See examples in `?profile_emissions_upstream`
 prepare_ictr_company <- function(ictr_comp, ictr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   ictr_prod <- sanitize_isic(ictr_prod)
 

--- a/R/prepare_ictr_product.R
+++ b/R/prepare_ictr_product.R
@@ -1,5 +1,8 @@
 #' Creates final output of ictr product level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param ictr_prod A dataframe like [ictr_product]
@@ -10,16 +13,9 @@
 #' @return A dataframe that prepares the final output of ictr_product
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' prepare_ictr_product(
-#'   ictr_product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   ecoinvent_inputs |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_ictr_product <- function(ictr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   ictr_prod <- sanitize_isic(ictr_prod)
 

--- a/R/prepare_ictr_product.R
+++ b/R/prepare_ictr_product.R
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_emissions_upstream`
 prepare_ictr_product <- function(ictr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   ictr_prod <- sanitize_isic(ictr_prod)
 

--- a/R/prepare_ictr_product.R
+++ b/R/prepare_ictr_product.R
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_emissions_upstream`
+#' # See examples in `?profile_emissions_upstream`
 prepare_ictr_product <- function(ictr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   ictr_prod <- sanitize_isic(ictr_prod)
 

--- a/R/prepare_istr_company.R
+++ b/R/prepare_istr_company.R
@@ -17,7 +17,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_sector_upstream`
+#' # See examples in `?profile_sector_upstream`
 prepare_istr_company <- function(istr_comp, istr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   istr_prod <- sanitize_isic(istr_prod)
   istr_comp <- sector_profile_any_polish_output_at_company_level(istr_comp)

--- a/R/prepare_istr_company.R
+++ b/R/prepare_istr_company.R
@@ -1,5 +1,8 @@
 #' Creates final output of istr company level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param istr_prod A dataframe like [istr_product]
@@ -12,20 +15,9 @@
 #' @return A dataframe that prepares the final output of ictr_company
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' company <- unnest_company(toy_sector_profile_upstream_output())
-#' product <- unnest_product(toy_sector_profile_upstream_output())
-#'
-#' prepare_istr_company(
-#'   company |> head(3),
-#'   product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   ecoinvent_inputs |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_istr_company <- function(istr_comp, istr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   istr_prod <- sanitize_isic(istr_prod)
   istr_comp <- sector_profile_any_polish_output_at_company_level(istr_comp)

--- a/R/prepare_istr_company.R
+++ b/R/prepare_istr_company.R
@@ -17,7 +17,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_sector_upstream`
 prepare_istr_company <- function(istr_comp, istr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   istr_prod <- sanitize_isic(istr_prod)
   istr_comp <- sector_profile_any_polish_output_at_company_level(istr_comp)

--- a/R/prepare_istr_product.R
+++ b/R/prepare_istr_product.R
@@ -1,5 +1,8 @@
 #' Creates final output of istr product level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param istr_prod A dataframe like [istr_product]
@@ -10,17 +13,9 @@
 #' @return A dataframe that prepares the final output of istr_product
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' product <- unnest_product(toy_sector_profile_upstream_output())
-#' prepare_istr_product(
-#'   product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   ecoinvent_inputs |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_istr_product <- function(istr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   istr_prod <- sanitize_isic(istr_prod)
 

--- a/R/prepare_istr_product.R
+++ b/R/prepare_istr_product.R
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_sector_upstream`
 prepare_istr_product <- function(istr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   istr_prod <- sanitize_isic(istr_prod)
 

--- a/R/prepare_istr_product.R
+++ b/R/prepare_istr_product.R
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_sector_upstream`
+#' # See examples in `?profile_sector_upstream`
 prepare_istr_product <- function(istr_prod, comp, eco_activities, match_mapper, eco_inputs, isic_tilt_map) {
   istr_prod <- sanitize_isic(istr_prod)
 

--- a/R/prepare_pctr_company.R
+++ b/R/prepare_pctr_company.R
@@ -1,5 +1,8 @@
 #' Creates final output of pctr company level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param pctr_prod A dataframe like [pctr_product]
@@ -10,16 +13,9 @@
 #' @return A dataframe that prepares the final output of pctr_company
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' prepare_pctr_company(
-#'   pctr_company |> head(3),
-#'   pctr_product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_pctr_company <- function(pctr_comp, pctr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pctr_prod <- sanitize_isic(pctr_prod)
 

--- a/R/prepare_pctr_company.R
+++ b/R/prepare_pctr_company.R
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_emissions`
 prepare_pctr_company <- function(pctr_comp, pctr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pctr_prod <- sanitize_isic(pctr_prod)
 

--- a/R/prepare_pctr_company.R
+++ b/R/prepare_pctr_company.R
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_emissions`
+#' # See examples in `?profile_emissions`
 prepare_pctr_company <- function(pctr_comp, pctr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pctr_prod <- sanitize_isic(pctr_prod)
 

--- a/R/prepare_pctr_product.R
+++ b/R/prepare_pctr_product.R
@@ -14,7 +14,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_emissions`
+#' # See examples in `?profile_emissions`
 prepare_pctr_product <- function(pctr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pctr_prod <- sanitize_isic(pctr_prod)
 

--- a/R/prepare_pctr_product.R
+++ b/R/prepare_pctr_product.R
@@ -1,5 +1,8 @@
 #' Creates final output of pctr product level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param pctr_prod A dataframe like [pctr_product]
@@ -9,15 +12,9 @@
 #' @return A dataframe that prepares the final output of pctr_product
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' prepare_pctr_product(
-#'   pctr_product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_pctr_product <- function(pctr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pctr_prod <- sanitize_isic(pctr_prod)
 

--- a/R/prepare_pctr_product.R
+++ b/R/prepare_pctr_product.R
@@ -14,7 +14,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_emissions`
 prepare_pctr_product <- function(pctr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pctr_prod <- sanitize_isic(pctr_prod)
 

--- a/R/prepare_pstr_company.R
+++ b/R/prepare_pstr_company.R
@@ -16,7 +16,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_sector_profile`
+#' # See examples in `?profile_sector_profile`
 prepare_pstr_company <- function(pstr_comp, pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pstr_prod <- sanitize_isic(pstr_prod)
   pstr_comp <- sector_profile_any_polish_output_at_company_level(pstr_comp)

--- a/R/prepare_pstr_company.R
+++ b/R/prepare_pstr_company.R
@@ -1,5 +1,8 @@
 #' Creates final output of pstr company level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param pstr_prod A dataframe like [pstr_product]
@@ -11,19 +14,9 @@
 #' @return A dataframe that prepares the final output of pstr_company
 #'
 #' @export
-#'
+#' @keywords internal
 #' @examples
-#' company <- unnest_company(toy_sector_profile_output())
-#' product <- unnest_product(toy_sector_profile_output())
-#'
-#' prepare_pstr_company(
-#'   company |> head(3),
-#'   product |> head(3),
-#'   ep_companies |> head(3),
-#'   ecoinvent_activities |> head(3),
-#'   matches_mapper |> head(3),
-#'   isic_tilt_mapper |> head(3)
-#' )
+#' See examples in `?profile_xxxxxxxxx`
 prepare_pstr_company <- function(pstr_comp, pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pstr_prod <- sanitize_isic(pstr_prod)
   pstr_comp <- sector_profile_any_polish_output_at_company_level(pstr_comp)

--- a/R/prepare_pstr_company.R
+++ b/R/prepare_pstr_company.R
@@ -16,7 +16,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_sector_profile`
 prepare_pstr_company <- function(pstr_comp, pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pstr_prod <- sanitize_isic(pstr_prod)
   pstr_comp <- sector_profile_any_polish_output_at_company_level(pstr_comp)

--- a/R/prepare_pstr_product.R
+++ b/R/prepare_pstr_product.R
@@ -14,7 +14,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_xxxxxxxxx`
+#' See examples in `?profile_sector_profile`
 prepare_pstr_product <- function(pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pstr_prod <- sanitize_isic(pstr_prod)
 

--- a/R/prepare_pstr_product.R
+++ b/R/prepare_pstr_product.R
@@ -14,7 +14,7 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' See examples in `?profile_sector_profile`
+#' # See examples in `?profile_sector_profile`
 prepare_pstr_product <- function(pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pstr_prod <- sanitize_isic(pstr_prod)
 

--- a/R/prepare_pstr_product.R
+++ b/R/prepare_pstr_product.R
@@ -1,5 +1,8 @@
 #' Creates final output of pstr product level results
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' @param match_mapper A dataframe like [matches_mapper]
 #' @param eco_activities A dataframe like [ecoinvent_activities]
 #' @param pstr_prod A dataframe like [pstr_product]
@@ -9,6 +12,9 @@
 #' @return A dataframe that prepares the final output of pstr_product
 #'
 #' @export
+#' @keywords internal
+#' @examples
+#' See examples in `?profile_xxxxxxxxx`
 prepare_pstr_product <- function(pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
   pstr_prod <- sanitize_isic(pstr_prod)
 

--- a/R/rename.R
+++ b/R/rename.R
@@ -1,8 +1,8 @@
 polish_emissions_profile_upstream_company <- prepare_ictr_company
-polish_emissions_profile_company <- prepare_pctr_company
 polish_emissions_profile_upstream_product <- prepare_ictr_product
-polish_emissions_profile_product <- prepare_pctr_product
-polish_sector_profile_product <- prepare_pstr_product
-polish_sector_profile_company <- prepare_pstr_company
-polish_sector_profile_upstream_product <- prepare_istr_product
 polish_sector_profile_upstream_company <- prepare_istr_company
+polish_sector_profile_upstream_product <- prepare_istr_product
+polish_emissions_profile_company <- prepare_pctr_company
+polish_emissions_profile_product <- prepare_pctr_product
+polish_sector_profile_company <- prepare_pstr_company
+polish_sector_profile_product <- prepare_pstr_product

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,23 +30,46 @@ devtools::install_github("2DegreesInvesting/tiltIndicatorAfter")
 
 ```{r}
 library(tiltIndicatorAfter)
+library(tiltToyData)
+library(readr, warn.conflicts = FALSE)
+
+options(readr.show_col_types = FALSE)
 
 packageVersion("tiltIndicatorAfter")
 
-prepare_pctr_product(
-  pctr_product,
-  ep_companies,
-  ecoinvent_activities,
-  matches_mapper,
-  isic_tilt_mapper
+companies <- read_csv(toy_emissions_profile_any_companies())
+products <- read_csv(toy_emissions_profile_products())
+
+result <- profile_emissions(
+  companies,
+  products,
+  # TODO: Move to tiltToyData
+  europages_companies = tiltIndicatorAfter::ep_companies,
+  ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
+  ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
+  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
 )
 
-prepare_pctr_company(
-  pctr_company,
-  pctr_product,
-  ep_companies,
-  ecoinvent_activities,
-  matches_mapper,
-  isic_tilt_mapper
+result |> unnest_product()
+
+result |> unnest_company()
+
+
+
+inputs <- read_csv(toy_emissions_profile_upstream_products())
+
+result <- profile_emissions_upstream(
+  companies,
+  inputs,
+  # TODO: Move to tiltToyData
+  europages_companies = tiltIndicatorAfter::ep_companies,
+  ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
+  ecoinvent_inputs = tiltIndicatorAfter::ecoinvent_inputs,
+  ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
+  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
 )
+
+result |> unnest_product()
+
+result |> unnest_company()
 ```

--- a/README.md
+++ b/README.md
@@ -23,60 +23,120 @@ devtools::install_github("2DegreesInvesting/tiltIndicatorAfter")
 
 ``` r
 library(tiltIndicatorAfter)
+library(tiltToyData)
+library(readr, warn.conflicts = FALSE)
+
+options(readr.show_col_types = FALSE)
 
 packageVersion("tiltIndicatorAfter")
-#> [1] '0.0.0.9006'
+#> [1] '0.0.0.9014'
 
-prepare_pctr_product(
-  pctr_product,
-  ep_companies,
-  ecoinvent_activities,
-  matches_mapper,
-  isic_tilt_mapper
+companies <- read_csv(toy_emissions_profile_any_companies())
+products <- read_csv(toy_emissions_profile_products())
+
+result <- profile_emissions(
+  companies,
+  products,
+  # TODO: Move to tiltToyData
+  europages_companies = tiltIndicatorAfter::ep_companies,
+  ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
+  ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
+  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
 )
-#> # A tibble: 25 × 21
-#>    companies_id company_name country PCTR_risk_category benchmark     ep_product
-#>    <chr>        <chr>        <chr>   <chr>              <chr>         <chr>     
-#>  1 id3          company C    austria <NA>               <NA>          <NA>      
-#>  2 id1          company A    germany high               all           building …
-#>  3 id1          company A    germany medium             isic_sec      building …
-#>  4 id1          company A    germany low                tilt_sec      building …
-#>  5 id1          company A    germany high               unit          building …
-#>  6 id1          company A    germany medium             unit_isic_sec building …
-#>  7 id1          company A    germany high               unit_tilt_sec building …
-#>  8 id1          company A    germany medium             all           machining 
-#>  9 id1          company A    germany medium             isic_sec      machining 
-#> 10 id1          company A    germany medium             tilt_sec      machining 
-#> # ℹ 15 more rows
-#> # ℹ 15 more variables: matched_activity_name <chr>,
-#> #   matched_reference_product <chr>, unit <chr>, multi_match <chr>,
+
+result |> unnest_product()
+#> # A tibble: 49 × 26
+#>    companies_id     company_name country PCTR_risk_category benchmark ep_product
+#>    <chr>            <chr>        <chr>   <chr>              <chr>     <chr>     
+#>  1 fleischerei-sti… <NA>         <NA>    high               all       stove     
+#>  2 fleischerei-sti… <NA>         <NA>    high               isic_4di… stove     
+#>  3 fleischerei-sti… <NA>         <NA>    high               tilt_sec… stove     
+#>  4 fleischerei-sti… <NA>         <NA>    high               unit      stove     
+#>  5 fleischerei-sti… <NA>         <NA>    high               unit_isi… stove     
+#>  6 fleischerei-sti… <NA>         <NA>    high               unit_til… stove     
+#>  7 fleischerei-sti… <NA>         <NA>    high               all       oven      
+#>  8 fleischerei-sti… <NA>         <NA>    medium             isic_4di… oven      
+#>  9 fleischerei-sti… <NA>         <NA>    medium             tilt_sec… oven      
+#> 10 fleischerei-sti… <NA>         <NA>    medium             unit      oven      
+#> # ℹ 39 more rows
+#> # ℹ 20 more variables: matched_activity_name <chr>,
+#> #   matched_reference_product <chr>, unit <chr>, multi_match <lgl>,
 #> #   matching_certainty <chr>, matching_certainty_company_average <chr>,
 #> #   tilt_sector <chr>, tilt_subsector <chr>, isic_4digit <chr>,
-#> #   isic_name <chr>, company_city <chr>, postcode <dbl>, address <chr>,
-#> #   main_activity <chr>, activity_uuid_product_uuid <chr>
+#> #   isic_4digit_name <chr>, company_city <chr>, postcode <dbl>, address <chr>,
+#> #   main_activity <chr>, activity_uuid_product_uuid <chr>, …
 
-prepare_pctr_company(
-  pctr_company,
-  pctr_product,
-  ep_companies,
-  ecoinvent_activities,
-  matches_mapper,
-  isic_tilt_mapper
-)
-#> # A tibble: 37 × 11
-#>    companies_id company_name country PCTR_share PCTR_risk_category benchmark
-#>    <chr>        <chr>        <chr>        <dbl> <chr>              <chr>    
-#>  1 id1          company A    germany        0.5 high               all      
-#>  2 id1          company A    germany        0.5 medium             all      
-#>  3 id1          company A    germany        0   low                all      
-#>  4 id1          company A    germany        0   high               isic_sec 
-#>  5 id1          company A    germany        1   medium             isic_sec 
-#>  6 id1          company A    germany        0   low                isic_sec 
-#>  7 id1          company A    germany        0   high               tilt_sec 
-#>  8 id1          company A    germany        0.5 medium             tilt_sec 
-#>  9 id1          company A    germany        0.5 low                tilt_sec 
-#> 10 id1          company A    germany        1   high               unit     
-#> # ℹ 27 more rows
+result |> unnest_company()
+#> # A tibble: 129 × 11
+#>    companies_id     company_name country PCTR_share PCTR_risk_category benchmark
+#>    <chr>            <chr>        <chr>        <dbl> <lgl>              <lgl>    
+#>  1 fleischerei-sti… <NA>         <NA>           1   NA                 NA       
+#>  2 fleischerei-sti… <NA>         <NA>           0   NA                 NA       
+#>  3 fleischerei-sti… <NA>         <NA>           0   NA                 NA       
+#>  4 fleischerei-sti… <NA>         <NA>           0.5 NA                 NA       
+#>  5 fleischerei-sti… <NA>         <NA>           0.5 NA                 NA       
+#>  6 fleischerei-sti… <NA>         <NA>           0   NA                 NA       
+#>  7 fleischerei-sti… <NA>         <NA>           0.5 NA                 NA       
+#>  8 fleischerei-sti… <NA>         <NA>           0.5 NA                 NA       
+#>  9 fleischerei-sti… <NA>         <NA>           0   NA                 NA       
+#> 10 fleischerei-sti… <NA>         <NA>           0.5 NA                 NA       
+#> # ℹ 119 more rows
 #> # ℹ 5 more variables: matching_certainty_company_average <chr>,
 #> #   company_city <chr>, postcode <dbl>, address <chr>, main_activity <chr>
+
+
+
+inputs <- read_csv(toy_emissions_profile_upstream_products())
+
+result <- profile_emissions_upstream(
+  companies,
+  inputs,
+  # TODO: Move to tiltToyData
+  europages_companies = tiltIndicatorAfter::ep_companies,
+  ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
+  ecoinvent_inputs = tiltIndicatorAfter::ecoinvent_inputs,
+  ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
+  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+)
+
+result |> unnest_product()
+#> # A tibble: 319 × 27
+#>    companies_id     company_name country ICTR_risk_category benchmark ep_product
+#>    <chr>            <chr>        <chr>   <chr>              <chr>     <chr>     
+#>  1 fleischerei-sti… <NA>         <NA>    high               all       stove     
+#>  2 fleischerei-sti… <NA>         <NA>    high               all       stove     
+#>  3 fleischerei-sti… <NA>         <NA>    medium             all       stove     
+#>  4 fleischerei-sti… <NA>         <NA>    high               all       stove     
+#>  5 fleischerei-sti… <NA>         <NA>    high               all       stove     
+#>  6 fleischerei-sti… <NA>         <NA>    low                all       stove     
+#>  7 fleischerei-sti… <NA>         <NA>    low                all       stove     
+#>  8 fleischerei-sti… <NA>         <NA>    high               all       stove     
+#>  9 fleischerei-sti… <NA>         <NA>    high               input_is… stove     
+#> 10 fleischerei-sti… <NA>         <NA>    high               input_is… stove     
+#> # ℹ 309 more rows
+#> # ℹ 21 more variables: matched_activity_name <chr>,
+#> #   matched_reference_product <chr>, unit <chr>, multi_match <lgl>,
+#> #   matching_certainty <chr>, matching_certainty_company_average <chr>,
+#> #   input_name <chr>, input_unit <chr>, input_tilt_sector <chr>,
+#> #   input_tilt_subsector <chr>, input_isic_4digit <chr>,
+#> #   input_isic_4digit_name <chr>, company_city <chr>, postcode <dbl>, …
+
+result |> unnest_company()
+#> # A tibble: 127 × 11
+#>    companies_id  company_name company_city country ICTR_share ICTR_risk_category
+#>    <chr>         <chr>        <chr>        <chr>        <dbl> <chr>             
+#>  1 fleischerei-… <NA>         <NA>         <NA>         0.571 high              
+#>  2 fleischerei-… <NA>         <NA>         <NA>         0.214 medium            
+#>  3 fleischerei-… <NA>         <NA>         <NA>         0.214 low               
+#>  4 fleischerei-… <NA>         <NA>         <NA>         0.357 high              
+#>  5 fleischerei-… <NA>         <NA>         <NA>         0.357 medium            
+#>  6 fleischerei-… <NA>         <NA>         <NA>         0.286 low               
+#>  7 fleischerei-… <NA>         <NA>         <NA>         0.429 high              
+#>  8 fleischerei-… <NA>         <NA>         <NA>         0.357 medium            
+#>  9 fleischerei-… <NA>         <NA>         <NA>         0.214 low               
+#> 10 fleischerei-… <NA>         <NA>         <NA>         0.429 high              
+#> # ℹ 117 more rows
+#> # ℹ 5 more variables: benchmark <chr>,
+#> #   matching_certainty_company_average <chr>, postcode <dbl>, address <chr>,
+#> #   main_activity <chr>
 ```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,10 +8,6 @@ reference:
     contents:
       - has_concept("top-level functions")
 
-  - title: Old API
-    contents:
-      - matches("prepare_")
-
   - title: Datasets
     contents:
       - -matches("..tr_")

--- a/man/prepare_ictr_company.Rd
+++ b/man/prepare_ictr_company.Rd
@@ -36,6 +36,6 @@ A dataframe that prepares the final output of ictr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_emissions_upstream`
+# See examples in `?profile_emissions_upstream`
 }
 \keyword{internal}

--- a/man/prepare_ictr_company.Rd
+++ b/man/prepare_ictr_company.Rd
@@ -36,6 +36,6 @@ A dataframe that prepares the final output of ictr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_emissions_upstream`
 }
 \keyword{internal}

--- a/man/prepare_ictr_company.Rd
+++ b/man/prepare_ictr_company.Rd
@@ -33,16 +33,9 @@ prepare_ictr_company(
 A dataframe that prepares the final output of ictr_company
 }
 \description{
-Creates final output of ictr company level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-prepare_ictr_company(
-  ictr_company |> head(3),
-  ictr_product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  ecoinvent_inputs |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_ictr_product.Rd
+++ b/man/prepare_ictr_product.Rd
@@ -30,15 +30,9 @@ prepare_ictr_product(
 A dataframe that prepares the final output of ictr_product
 }
 \description{
-Creates final output of ictr product level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-prepare_ictr_product(
-  ictr_product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  ecoinvent_inputs |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_ictr_product.Rd
+++ b/man/prepare_ictr_product.Rd
@@ -33,6 +33,6 @@ A dataframe that prepares the final output of ictr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_emissions_upstream`
 }
 \keyword{internal}

--- a/man/prepare_ictr_product.Rd
+++ b/man/prepare_ictr_product.Rd
@@ -33,6 +33,6 @@ A dataframe that prepares the final output of ictr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_emissions_upstream`
+# See examples in `?profile_emissions_upstream`
 }
 \keyword{internal}

--- a/man/prepare_istr_company.Rd
+++ b/man/prepare_istr_company.Rd
@@ -34,19 +34,9 @@ from tiltIndicator.}
 A dataframe that prepares the final output of ictr_company
 }
 \description{
-Creates final output of istr company level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-company <- unnest_company(toy_sector_profile_upstream_output())
-product <- unnest_product(toy_sector_profile_upstream_output())
-
-prepare_istr_company(
-  company |> head(3),
-  product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  ecoinvent_inputs |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_istr_company.Rd
+++ b/man/prepare_istr_company.Rd
@@ -37,6 +37,6 @@ A dataframe that prepares the final output of ictr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_sector_upstream`
 }
 \keyword{internal}

--- a/man/prepare_istr_company.Rd
+++ b/man/prepare_istr_company.Rd
@@ -37,6 +37,6 @@ A dataframe that prepares the final output of ictr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_sector_upstream`
+# See examples in `?profile_sector_upstream`
 }
 \keyword{internal}

--- a/man/prepare_istr_product.Rd
+++ b/man/prepare_istr_product.Rd
@@ -33,6 +33,6 @@ A dataframe that prepares the final output of istr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_sector_upstream`
 }
 \keyword{internal}

--- a/man/prepare_istr_product.Rd
+++ b/man/prepare_istr_product.Rd
@@ -33,6 +33,6 @@ A dataframe that prepares the final output of istr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_sector_upstream`
+# See examples in `?profile_sector_upstream`
 }
 \keyword{internal}

--- a/man/prepare_istr_product.Rd
+++ b/man/prepare_istr_product.Rd
@@ -30,16 +30,9 @@ prepare_istr_product(
 A dataframe that prepares the final output of istr_product
 }
 \description{
-Creates final output of istr product level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-product <- unnest_product(toy_sector_profile_upstream_output())
-prepare_istr_product(
-  product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  ecoinvent_inputs |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_pctr_company.Rd
+++ b/man/prepare_pctr_company.Rd
@@ -33,6 +33,6 @@ A dataframe that prepares the final output of pctr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_emissions`
+# See examples in `?profile_emissions`
 }
 \keyword{internal}

--- a/man/prepare_pctr_company.Rd
+++ b/man/prepare_pctr_company.Rd
@@ -33,6 +33,6 @@ A dataframe that prepares the final output of pctr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_emissions`
 }
 \keyword{internal}

--- a/man/prepare_pctr_company.Rd
+++ b/man/prepare_pctr_company.Rd
@@ -30,15 +30,9 @@ prepare_pctr_company(
 A dataframe that prepares the final output of pctr_company
 }
 \description{
-Creates final output of pctr company level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-prepare_pctr_company(
-  pctr_company |> head(3),
-  pctr_product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_pctr_product.Rd
+++ b/man/prepare_pctr_product.Rd
@@ -27,14 +27,9 @@ prepare_pctr_product(
 A dataframe that prepares the final output of pctr_product
 }
 \description{
-Creates final output of pctr product level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-prepare_pctr_product(
-  pctr_product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_pctr_product.Rd
+++ b/man/prepare_pctr_product.Rd
@@ -30,6 +30,6 @@ A dataframe that prepares the final output of pctr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_emissions`
 }
 \keyword{internal}

--- a/man/prepare_pctr_product.Rd
+++ b/man/prepare_pctr_product.Rd
@@ -30,6 +30,6 @@ A dataframe that prepares the final output of pctr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_emissions`
+# See examples in `?profile_emissions`
 }
 \keyword{internal}

--- a/man/prepare_pstr_company.Rd
+++ b/man/prepare_pstr_company.Rd
@@ -34,6 +34,6 @@ A dataframe that prepares the final output of pstr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_sector_profile`
+# See examples in `?profile_sector_profile`
 }
 \keyword{internal}

--- a/man/prepare_pstr_company.Rd
+++ b/man/prepare_pstr_company.Rd
@@ -31,18 +31,9 @@ from tiltIndicator.}
 A dataframe that prepares the final output of pstr_company
 }
 \description{
-Creates final output of pstr company level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-company <- unnest_company(toy_sector_profile_output())
-product <- unnest_product(toy_sector_profile_output())
-
-prepare_pstr_company(
-  company |> head(3),
-  product |> head(3),
-  ep_companies |> head(3),
-  ecoinvent_activities |> head(3),
-  matches_mapper |> head(3),
-  isic_tilt_mapper |> head(3)
-)
+See examples in `?profile_xxxxxxxxx`
 }
+\keyword{internal}

--- a/man/prepare_pstr_company.Rd
+++ b/man/prepare_pstr_company.Rd
@@ -34,6 +34,6 @@ A dataframe that prepares the final output of pstr_company
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_sector_profile`
 }
 \keyword{internal}

--- a/man/prepare_pstr_product.Rd
+++ b/man/prepare_pstr_product.Rd
@@ -30,6 +30,6 @@ A dataframe that prepares the final output of pstr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_xxxxxxxxx`
+See examples in `?profile_sector_profile`
 }
 \keyword{internal}

--- a/man/prepare_pstr_product.Rd
+++ b/man/prepare_pstr_product.Rd
@@ -27,5 +27,9 @@ prepare_pstr_product(
 A dataframe that prepares the final output of pstr_product
 }
 \description{
-Creates final output of pstr product level results
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
+\examples{
+See examples in `?profile_xxxxxxxxx`
+}
+\keyword{internal}

--- a/man/prepare_pstr_product.Rd
+++ b/man/prepare_pstr_product.Rd
@@ -30,6 +30,6 @@ A dataframe that prepares the final output of pstr_product
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
-See examples in `?profile_sector_profile`
+# See examples in `?profile_sector_profile`
 }
 \keyword{internal}


### PR DESCRIPTION
Replaces https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/93 because that one got too entangled
Closes https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues/83

This PR deprecates the old API in favor of the new API. It follows the process documented [here](https://lifecycle.r-lib.org/articles/communicate.html#functions) except that I don't introduce a warning if the old API is called -- which is quite a bit of work because then we need to suppress the warning from each test that indirectly calls the old API. That work would be worth for a package that was used by external users, but so far I believe the users are all internal.

The signs of deprecation are:

* A badge in the helpfile.
* The removal of the examples and a redirection to examples in the new API.
* The removal of the old API from the website's Reference.
* Replacing the example in README with another example showing the new API.
