### PR TITLE
Test the` profile*()` functions don't pad `*isic*`

### DIFF
--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -6,3 +6,7 @@ tibble_names <- function(x, nms) {
   m <- matrix(x, ncol = length(nms), dimnames = list(NULL, nms))
   tibble::as_tibble(m)
 }
+
+rm_na <- function(x) {
+  x[!is.na(x)]
+}

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -76,3 +76,28 @@ test_that("the output at product level has columns matching isic and sector", {
   expect_true(any(matches_name(product, "isic")))
   expect_true(any(matches_name(product, "sector")))
 })
+
+test_that("doesn't pad `*isic*`", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_emissions_profile_any_companies())
+  co2 <- read_csv(toy_emissions_profile_products())
+  co2$isic_4digit <- "1"
+
+  europages_companies <- ep_companies |> head(3)
+  ecoinvent_activities <- ecoinvent_activities
+  ecoinvent_europages <- small_matches_mapper |> head(3)
+  isic_tilt <- isic_tilt_mapper |> head(3)
+
+  out <- profile_emissions(
+    companies,
+    co2,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_europages,
+    isic_tilt
+  )
+
+  actual <- rm_na(unique(unnest_product(out)$isic_4digit))
+  expect_equal(actual, "1")
+})

--- a/tests/testthat/test-profile_emissions_upstream.R
+++ b/tests/testthat/test-profile_emissions_upstream.R
@@ -83,3 +83,30 @@ test_that("the output at product level has columns matching isic and sector", {
   expect_true(any(matches_name(product, "isic")))
   expect_true(any(matches_name(product, "sector")))
 })
+
+test_that("doesn't pad `*isic*`", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_emissions_profile_any_companies())
+  co2 <- read_csv(toy_emissions_profile_upstream_products())
+  co2$input_isic_4digit <- "1"
+
+  europages_companies <- ep_companies |> head(3)
+  ecoinvent_activities <- ecoinvent_activities |> head(3)
+  ecoinvent_inputs <- ecoinvent_inputs |> head(3)
+  ecoinvent_europages <- small_matches_mapper |> head(3)
+  isic_tilt <- isic_tilt_mapper |> head(3)
+
+  out <- profile_emissions_upstream(
+    companies,
+    co2,
+    europages_companies = europages_companies,
+    ecoinvent_activities = ecoinvent_activities,
+    ecoinvent_inputs = ecoinvent_inputs,
+    ecoinvent_europages = ecoinvent_europages,
+    isic_tilt = isic_tilt
+  )
+
+  actual <- rm_na(unique(unnest_product(out)$input_isic_4digit))
+  expect_equal(actual, "1")
+})

--- a/tests/testthat/test-profile_sector.R
+++ b/tests/testthat/test-profile_sector.R
@@ -80,3 +80,28 @@ test_that("the output at product level has columns matching isic and sector", {
   expect_true(any(matches_name(product, "isic")))
   expect_true(any(matches_name(product, "sector")))
 })
+
+test_that("doesn't pad `*isic*`", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_sector_profile_companies())
+  companies$isic_4digit <- "1"
+
+  scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  europages_companies <- ep_companies |> head(3)
+  ecoinvent_activities <- ecoinvent_activities |> head(3)
+  ecoinvent_europages <- small_matches_mapper |> head(3)
+  isic_tilt <- isic_tilt_mapper |> head(3)
+
+  out <- profile_sector(
+    companies,
+    scenarios,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_europages,
+    isic_tilt
+  )
+
+  actual <- rm_na(unique(unnest_product(out)$isic_4digit))
+  expect_equal(actual, "1")
+})

--- a/tests/testthat/test-profile_sector_upstream.R
+++ b/tests/testthat/test-profile_sector_upstream.R
@@ -88,3 +88,32 @@ test_that("the output at product level has columns matching isic and sector", {
   expect_true(any(matches_name(product, "isic")))
   expect_true(any(matches_name(product, "sector")))
 })
+
+test_that("doesn't pad `*isic*`", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_sector_profile_upstream_companies())
+  scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  inputs <- read_csv(toy_sector_profile_upstream_products())
+  inputs$input_isic_4digit <- "1"
+
+  europages_companies <- ep_companies |> head(3)
+  ecoinvent_activities <- ecoinvent_activities |> head(3)
+  ecoinvent_europages <- small_matches_mapper |> head(3)
+  ecoinvent_inputs <- ecoinvent_inputs |> head(3)
+  isic_tilt <- isic_tilt_mapper |> head(3)
+
+  out <- profile_sector_upstream(
+    companies,
+    scenarios,
+    inputs,
+    europages_companies = europages_companies,
+    ecoinvent_activities = ecoinvent_activities,
+    ecoinvent_inputs = ecoinvent_inputs,
+    ecoinvent_europages = ecoinvent_europages,
+    isic_tilt
+  )
+
+  actual <- rm_na(unique(unnest_product(out)$input_isic_4digit))
+  expect_equal(actual, "1")
+})


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltIndicator/issues/635
Relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/82#discussion_r1410505708

We tested this before via `sanitize_co2()` but not through the public API. This PR adds such tests to avoid a regression.