### PR TITLE
Adapt tests to new 'quoted' values of isic

### DIFF
--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -1,3 +1,7 @@
+unquote <- function(x) {
+  gsub("^'(.*)'$", "\\1", x)
+}
+
 format_minimal_snapshot <- function(data) {
   str(data, give.attr = FALSE)
 }

--- a/tests/testthat/test-prepare_ictr_company.R
+++ b/tests/testthat/test-prepare_ictr_company.R
@@ -30,7 +30,7 @@ test_that("handles numeric `isic*` in `co2`", {
   expect_no_error(
     profile_emissions_upstream(
       companies,
-      co2 |> modify_col("isic", as.numeric),
+      co2 |> modify_col("isic", unquote) |> modify_col("isic", as.numeric),
       europages_companies = ep_companies,
       ecoinvent_activities,
       ecoinvent_inputs = ecoinvent_inputs,

--- a/tests/testthat/test-prepare_pctr_company.R
+++ b/tests/testthat/test-prepare_pctr_company.R
@@ -29,7 +29,7 @@ test_that("handles numeric `isic*` in `co2`", {
   expect_no_error(
     profile_emissions(
       companies,
-      co2 |> head(3) |> modify_col("isic", as.numeric),
+      co2 |> modify_col("isic", unquote) |> modify_col("isic", as.numeric),
       europages_companies = ep_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europage = small_matches_mapper,


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltToyData/pull/17

This PR adapts tests to work with quoted values of `*isic*` -- which will be introduced soon via https://github.com/2DegreesInvesting/tiltToyData/pull/17. 

The affected tests may be obsolete and instead of handling numeric `*isic*` we should throw a warning or error -- see https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues/102

