### PR TITLE
Avoid breaking tiltWorkflows

### DIFF
--- a/.github/workflows/R-CMD-check-tiltWorkflows.yaml
+++ b/.github/workflows/R-CMD-check-tiltWorkflows.yaml
@@ -1,0 +1,55 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check tiltWorkflows
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/checkout@v3
+      with:
+        repository: 2DegreesInvesting/tiltWorkflows
+        ref: main
+        path: tiltWorkflows
+
+    - uses: r-lib/actions/setup-pandoc@v2
+
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{ matrix.config.r }}
+        http-user-agent: ${{ matrix.config.http-user-agent }}
+        use-public-rspm: true
+
+    - uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        extra-packages: any::rcmdcheck
+        needs: check
+        working-directory: tiltWorkflows
+
+    - name: Install tiltToyData
+      run: |
+        Rscript -e "pak::local_install()"
+
+    - uses: r-lib/actions/check-r-package@v2
+      with:
+        upload-snapshots: true
+        working-directory: tiltWorkflows


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to avoid breaking tiltWorkflows. It checkout the PR from this repo, then runs R CMD check on tiltWorkflows.