### PR TITLE
WAIT for #112. Rename the argument `isic_tilt` to `isic` in all `profile*()` functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Depends:
 Imports: 
     dplyr,
     glue,
+    lifecycle,
     memoise,
     readr,
     rlang,

--- a/R/prepare_ictr_product.R
+++ b/R/prepare_ictr_product.R
@@ -3,12 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param ictr_prod A dataframe like [ictr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param eco_inputs A dataframe like [ecoinvent_inputs]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of ictr_product
 #'

--- a/R/prepare_inter_pctr_product.R
+++ b/R/prepare_inter_pctr_product.R
@@ -1,10 +1,6 @@
 #' Creates intermediate output of pctr product level results
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param pctr_prod A dataframe like [pctr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the intermediate output of pctr_product
 #' @noRd

--- a/R/prepare_inter_pstr_product.R
+++ b/R/prepare_inter_pstr_product.R
@@ -1,10 +1,6 @@
 #' Creates intermediate output of pstr product level results
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param pstr_prod A dataframe like [pstr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the intermediate output of pstr_product
 #' @noRd

--- a/R/prepare_istr_company.R
+++ b/R/prepare_istr_company.R
@@ -3,14 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param istr_prod A dataframe like [istr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param istr_comp A dataframe like the corresponding output at company level
-#'   from tiltIndicator.
-#' @param eco_inputs A dataframe like [ecoinvent_inputs]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of ictr_company
 #'

--- a/R/prepare_istr_product.R
+++ b/R/prepare_istr_product.R
@@ -3,12 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param istr_prod A dataframe like [istr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param eco_inputs A dataframe like [ecoinvent_inputs]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of istr_product
 #'

--- a/R/prepare_pctr_company.R
+++ b/R/prepare_pctr_company.R
@@ -3,12 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param pctr_prod A dataframe like [pctr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param pctr_comp A dataframe like [pctr_company]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of pctr_company
 #'

--- a/R/prepare_pctr_product.R
+++ b/R/prepare_pctr_product.R
@@ -3,11 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param pctr_prod A dataframe like [pctr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of pctr_product
 #'

--- a/R/prepare_pstr_company.R
+++ b/R/prepare_pstr_company.R
@@ -3,13 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param pstr_prod A dataframe like [pstr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
-#' @param pstr_comp A dataframe like the corresponding output at company level
-#'   from tiltIndicator.
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of pstr_company
 #'

--- a/R/prepare_pstr_product.R
+++ b/R/prepare_pstr_product.R
@@ -3,11 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' @param match_mapper A dataframe like [matches_mapper]
-#' @param eco_activities A dataframe like [ecoinvent_activities]
-#' @param pstr_prod A dataframe like [pstr_product]
-#' @param comp A dataframe like [ep_companies]
-#' @param isic_tilt_map A dataframe like [isic_tilt_mapper]
+#' @inheritParams prepare_ictr_company
 #'
 #' @return A dataframe that prepares the final output of pstr_product
 #'

--- a/R/profile_emissions.R
+++ b/R/profile_emissions.R
@@ -5,9 +5,19 @@ profile_emissions <- function(companies,
                               europages_companies,
                               ecoinvent_activities,
                               ecoinvent_europages,
-                              isic_tilt,
+                              isic,
+                              isic_tilt = lifecycle::deprecated(),
                               low_threshold = 1 / 3,
                               high_threshold = 2 / 3) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017",
+      "profile_emissions(isic_tilt)",
+      "profile_emissions(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   europages_companies <- select_europages_companies(europages_companies)
 
   indicator <- list(
@@ -20,7 +30,7 @@ profile_emissions <- function(companies,
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
   exec_profile("emissions_profile", indicator, indicator_after)
 }

--- a/R/profile_emissions_upstream.R
+++ b/R/profile_emissions_upstream.R
@@ -31,7 +31,7 @@
 #'   europages_companies = tiltIndicatorAfter::ep_companies,
 #'   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
 #'   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-#'   isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+#'   isic = tiltIndicatorAfter::isic_tilt_mapper
 #' )
 #'
 #' result |> unnest_product()
@@ -50,7 +50,7 @@
 #'   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
 #'   ecoinvent_inputs = tiltIndicatorAfter::ecoinvent_inputs,
 #'   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-#'   isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+#'   isic = tiltIndicatorAfter::isic_tilt_mapper
 #' )
 #'
 #' result |> unnest_product()
@@ -62,9 +62,19 @@ profile_emissions_upstream <- function(companies,
                                        ecoinvent_activities,
                                        ecoinvent_inputs,
                                        ecoinvent_europages,
-                                       isic_tilt,
+                                       isic,
+                                       isic_tilt = lifecycle::deprecated(),
                                        low_threshold = 1 / 3,
                                        high_threshold = 2 / 3) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017",
+      "profile_emissions_upstream(isic_tilt)",
+      "profile_emissions_upstream(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   europages_companies <- select_europages_companies(europages_companies)
   ecoinvent_inputs <- select_ecoinvent_inputs(ecoinvent_inputs)
 
@@ -79,7 +89,7 @@ profile_emissions_upstream <- function(companies,
     ecoinvent_activities,
     ecoinvent_europages,
     ecoinvent_inputs,
-    isic_tilt
+    isic
   )
   exec_profile("emissions_profile_upstream", indicator, indicator_after)
 }

--- a/R/profile_emissions_upstream.R
+++ b/R/profile_emissions_upstream.R
@@ -8,7 +8,8 @@
 #' @param ecoinvent_activities Dataframe. Activities from ecoinvent.
 #' @param ecoinvent_inputs Dataframe. Upstream products from ecoinvent.
 #' @param ecoinvent_europages Dataframe. Mapper between europages and ecoinvent.
-#' @param isic_tilt Dataframe. Mapper between isic and tilt.
+#' @param isic Dataframe. ISIC data.
+#' @param isic_tilt `r lifecycle::badge("deprecated")`
 #'
 #' @return `r document_default_value()`
 #' @export

--- a/R/profile_sector.R
+++ b/R/profile_sector.R
@@ -5,9 +5,19 @@ profile_sector <- function(companies,
                            europages_companies,
                            ecoinvent_activities,
                            ecoinvent_europages,
-                           isic_tilt,
+                           isic,
+                           isic_tilt = lifecycle::deprecated(),
                            low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017",
+      "profile_sector(isic_tilt)",
+      "profile_sector(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   europages_companies <- select_europages_companies(europages_companies)
 
   indicator <- list(
@@ -20,7 +30,7 @@ profile_sector <- function(companies,
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
   exec_profile("sector_profile", indicator, indicator_after)
 }

--- a/R/profile_sector_upstream.R
+++ b/R/profile_sector_upstream.R
@@ -23,7 +23,7 @@
 #'   europages_companies = ep_companies |> head(3),
 #'   ecoinvent_activities = ecoinvent_activities |> head(3),
 #'   ecoinvent_europages = matches_mapper |> head(3),
-#'   isic_tilt = isic_tilt_mapper |> head(3)
+#'   isic = isic_tilt_mapper |> head(3)
 #' )
 #'
 #' result |> unnest_product()
@@ -46,7 +46,7 @@
 #'   ecoinvent_activities = ecoinvent_activities |> head(3),
 #'   ecoinvent_inputs = ecoinvent_inputs |> head(3),
 #'   ecoinvent_europages = matches_mapper |> head(3),
-#'   isic_tilt = isic_tilt_mapper |> head(3)
+#'   isic = isic_tilt_mapper |> head(3)
 #' )
 #'
 #' result |> unnest_product()
@@ -59,9 +59,19 @@ profile_sector_upstream <- function(companies,
                                     ecoinvent_activities,
                                     ecoinvent_inputs,
                                     ecoinvent_europages,
-                                    isic_tilt,
+                                    isic,
+                                    isic_tilt = lifecycle::deprecated(),
                                     low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017",
+      "profile_sector_upstream(isic_tilt)",
+      "profile_sector_upstream(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   europages_companies <- select_europages_companies(europages_companies)
   ecoinvent_inputs <- select_ecoinvent_inputs(ecoinvent_inputs)
 
@@ -77,7 +87,7 @@ profile_sector_upstream <- function(companies,
     ecoinvent_activities,
     ecoinvent_europages,
     ecoinvent_inputs,
-    isic_tilt
+    isic
   )
   exec_profile("sector_profile_upstream", indicator, indicator_after)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ result <- profile_emissions(
   europages_companies = tiltIndicatorAfter::ep_companies,
   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+  isic = tiltIndicatorAfter::isic_tilt_mapper
 )
 
 result |> unnest_product()
@@ -66,7 +66,7 @@ result <- profile_emissions_upstream(
   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
   ecoinvent_inputs = tiltIndicatorAfter::ecoinvent_inputs,
   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+  isic = tiltIndicatorAfter::isic_tilt_mapper
 )
 
 result |> unnest_product()

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ library(readr, warn.conflicts = FALSE)
 options(readr.show_col_types = FALSE)
 
 packageVersion("tiltIndicatorAfter")
-#> [1] '0.0.0.9014'
+#> [1] '0.0.0.9016'
 
 companies <- read_csv(toy_emissions_profile_any_companies())
 products <- read_csv(toy_emissions_profile_products())
@@ -41,7 +41,7 @@ result <- profile_emissions(
   europages_companies = tiltIndicatorAfter::ep_companies,
   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+  isic = tiltIndicatorAfter::isic_tilt_mapper
 )
 
 result |> unnest_product()
@@ -96,7 +96,7 @@ result <- profile_emissions_upstream(
   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
   ecoinvent_inputs = tiltIndicatorAfter::ecoinvent_inputs,
   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+  isic = tiltIndicatorAfter::isic_tilt_mapper
 )
 
 result |> unnest_product()

--- a/man/prepare_istr_company.Rd
+++ b/man/prepare_istr_company.Rd
@@ -15,11 +15,6 @@ prepare_istr_company(
 )
 }
 \arguments{
-\item{istr_comp}{A dataframe like the corresponding output at company level
-from tiltIndicator.}
-
-\item{istr_prod}{A dataframe like \link{istr_product}}
-
 \item{comp}{A dataframe like \link{ep_companies}}
 
 \item{eco_activities}{A dataframe like \link{ecoinvent_activities}}

--- a/man/prepare_istr_product.Rd
+++ b/man/prepare_istr_product.Rd
@@ -14,8 +14,6 @@ prepare_istr_product(
 )
 }
 \arguments{
-\item{istr_prod}{A dataframe like \link{istr_product}}
-
 \item{comp}{A dataframe like \link{ep_companies}}
 
 \item{eco_activities}{A dataframe like \link{ecoinvent_activities}}

--- a/man/prepare_pctr_company.Rd
+++ b/man/prepare_pctr_company.Rd
@@ -14,10 +14,6 @@ prepare_pctr_company(
 )
 }
 \arguments{
-\item{pctr_comp}{A dataframe like \link{pctr_company}}
-
-\item{pctr_prod}{A dataframe like \link{pctr_product}}
-
 \item{comp}{A dataframe like \link{ep_companies}}
 
 \item{eco_activities}{A dataframe like \link{ecoinvent_activities}}

--- a/man/prepare_pctr_product.Rd
+++ b/man/prepare_pctr_product.Rd
@@ -13,8 +13,6 @@ prepare_pctr_product(
 )
 }
 \arguments{
-\item{pctr_prod}{A dataframe like \link{pctr_product}}
-
 \item{comp}{A dataframe like \link{ep_companies}}
 
 \item{eco_activities}{A dataframe like \link{ecoinvent_activities}}

--- a/man/prepare_pstr_company.Rd
+++ b/man/prepare_pstr_company.Rd
@@ -14,11 +14,6 @@ prepare_pstr_company(
 )
 }
 \arguments{
-\item{pstr_comp}{A dataframe like the corresponding output at company level
-from tiltIndicator.}
-
-\item{pstr_prod}{A dataframe like \link{pstr_product}}
-
 \item{comp}{A dataframe like \link{ep_companies}}
 
 \item{eco_activities}{A dataframe like \link{ecoinvent_activities}}

--- a/man/prepare_pstr_product.Rd
+++ b/man/prepare_pstr_product.Rd
@@ -13,8 +13,6 @@ prepare_pstr_product(
 )
 }
 \arguments{
-\item{pstr_prod}{A dataframe like \link{pstr_product}}
-
 \item{comp}{A dataframe like \link{ep_companies}}
 
 \item{eco_activities}{A dataframe like \link{ecoinvent_activities}}

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -12,7 +12,8 @@ profile_emissions(
   europages_companies,
   ecoinvent_activities,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = 1/3,
   high_threshold = 2/3
 )

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -40,7 +40,9 @@ profile_emissions_upstream(
 
 \item{ecoinvent_europages}{Dataframe. Mapper between europages and ecoinvent.}
 
-\item{isic_tilt}{Dataframe. Mapper between isic and tilt.}
+\item{isic}{Dataframe. ISIC data.}
+
+\item{isic_tilt}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 
 \item{low_threshold}{A numeric value to segment low and medium transition
 risk products.}

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -25,7 +25,8 @@ profile_emissions_upstream(
   ecoinvent_activities,
   ecoinvent_inputs,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = 1/3,
   high_threshold = 2/3
 )
@@ -72,7 +73,7 @@ result <- profile_emissions(
   europages_companies = tiltIndicatorAfter::ep_companies,
   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+  isic = tiltIndicatorAfter::isic_tilt_mapper
 )
 
 result |> unnest_product()
@@ -91,7 +92,7 @@ result <- profile_emissions_upstream(
   ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
   ecoinvent_inputs = tiltIndicatorAfter::ecoinvent_inputs,
   ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
-  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
+  isic = tiltIndicatorAfter::isic_tilt_mapper
 )
 
 result |> unnest_product()

--- a/man/profile_sector_upstream.Rd
+++ b/man/profile_sector_upstream.Rd
@@ -11,7 +11,8 @@ profile_sector(
   europages_companies,
   ecoinvent_activities,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = ifelse(scenarios$year == 2030, 1/9, 1/3),
   high_threshold = ifelse(scenarios$year == 2030, 2/9, 2/3)
 )
@@ -39,7 +40,9 @@ profile_sector_upstream(
 
 \item{ecoinvent_europages}{Dataframe. Mapper between europages and ecoinvent.}
 
-\item{isic_tilt}{Dataframe. Mapper between isic and tilt.}
+\item{isic}{Dataframe. ISIC data.}
+
+\item{isic_tilt}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 
 \item{low_threshold}{A numeric value to segment low and medium transition
 risk products.}

--- a/man/profile_sector_upstream.Rd
+++ b/man/profile_sector_upstream.Rd
@@ -24,7 +24,8 @@ profile_sector_upstream(
   ecoinvent_activities,
   ecoinvent_inputs,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = ifelse(scenarios$year == 2030, 1/9, 1/3),
   high_threshold = ifelse(scenarios$year == 2030, 2/9, 2/3)
 )
@@ -71,7 +72,7 @@ result <- profile_sector(
   europages_companies = ep_companies |> head(3),
   ecoinvent_activities = ecoinvent_activities |> head(3),
   ecoinvent_europages = matches_mapper |> head(3),
-  isic_tilt = isic_tilt_mapper |> head(3)
+  isic = isic_tilt_mapper |> head(3)
 )
 
 result |> unnest_product()
@@ -94,7 +95,7 @@ result <- profile_sector_upstream(
   ecoinvent_activities = ecoinvent_activities |> head(3),
   ecoinvent_inputs = ecoinvent_inputs |> head(3),
   ecoinvent_europages = matches_mapper |> head(3),
-  isic_tilt = isic_tilt_mapper |> head(3)
+  isic = isic_tilt_mapper |> head(3)
 )
 
 result |> unnest_product()

--- a/tests/testthat/test-prepare_ictr_company.R
+++ b/tests/testthat/test-prepare_ictr_company.R
@@ -12,7 +12,7 @@ test_that("total number of rows for a comapny is either 1 or 3", {
     ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_company() |>
     group_by(companies_id, benchmark) |>
@@ -35,7 +35,7 @@ test_that("handles numeric `isic*` in `co2`", {
       ecoinvent_activities,
       ecoinvent_inputs = ecoinvent_inputs,
       ecoinvent_europages = small_matches_mapper,
-      isic_tilt = isic_tilt_mapper
+      isic = isic_tilt_mapper
     )
   )
 })

--- a/tests/testthat/test-prepare_istr_company.R
+++ b/tests/testthat/test-prepare_istr_company.R
@@ -13,7 +13,7 @@ test_that("total number of rows for a comapny is either 1 or 3", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_company() |>
     group_by(companies_id, scenario, year) |>

--- a/tests/testthat/test-prepare_pctr_company.R
+++ b/tests/testthat/test-prepare_pctr_company.R
@@ -12,7 +12,7 @@ test_that("total number of rows for a comapny is either 1 or 3", {
     europages_companies = ep_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europage = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_company() |>
     group_by(companies_id, benchmark) |>
@@ -33,7 +33,7 @@ test_that("handles numeric `isic*` in `co2`", {
       europages_companies = ep_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europage = small_matches_mapper,
-      isic_tilt = isic_tilt_mapper
+      isic = isic_tilt_mapper
     )
   )
 })

--- a/tests/testthat/test-prepare_pctr_product.R
+++ b/tests/testthat/test-prepare_pctr_product.R
@@ -11,7 +11,7 @@ test_that("total number of rows for a comapny is either 1 or 6", {
     europages_companies = ep_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_product() |>
     group_by(companies_id, ep_product, activity_uuid_product_uuid) |>
@@ -32,7 +32,7 @@ test_that("doesn't throw error: 'Column unit doesn't exist' (#26)", {
       europages_companies = ep_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europages = small_matches_mapper,
-      isic_tilt = isic_tilt_mapper
+      isic = isic_tilt_mapper
     )
   )
 })

--- a/tests/testthat/test-prepare_pstr_company.R
+++ b/tests/testthat/test-prepare_pstr_company.R
@@ -10,7 +10,7 @@ test_that("total number of rows for a comapny is either 1 or 3", {
     europages_companies = ep_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_company() |>
     group_by(companies_id, scenario, year) |>
@@ -32,7 +32,7 @@ test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", 
     europages_companies = ep_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_company()
 

--- a/tests/testthat/test-prepare_pstr_product.R
+++ b/tests/testthat/test-prepare_pstr_product.R
@@ -28,7 +28,7 @@ test_that("'empty' tiltIndicator results yield at most 1 NA in *risk_category", 
     europages_companies = ep_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_product()
 
@@ -55,7 +55,7 @@ test_that("yield NA in `*tilt_sector` and `*tilt_subsector` for no risk category
     europages_companies = ep_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = small_matches_mapper,
-    isic_tilt = isic_tilt_mapper
+    isic = isic_tilt_mapper
   ) |>
     unnest_product()
 

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -6,7 +6,7 @@ test_that("characterize columns", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_emissions(
     companies,
@@ -14,7 +14,7 @@ test_that("characterize columns", {
     europages_companies = europages_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt = isic_tilt
+    isic = isic
   )
 
   expect_snapshot(names(unnest_product(out)))
@@ -30,7 +30,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   # New API
   out <- profile_emissions(
@@ -39,7 +39,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     europages_companies = europages_companies,
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt = isic_tilt
+    isic = isic
   )
 
   # Old API
@@ -55,7 +55,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   out_company <- prepare_pctr_company(
@@ -64,7 +64,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   new <- arrange(unnest_product(out), companies_id)
@@ -85,7 +85,7 @@ test_that("the output at product level has columns matching isic and sector", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_emissions(
     companies,
@@ -93,7 +93,7 @@ test_that("the output at product level has columns matching isic and sector", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   product <- unnest_product(out)
@@ -111,7 +111,7 @@ test_that("doesn't pad `*isic*`", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_emissions(
     companies,
@@ -119,7 +119,7 @@ test_that("doesn't pad `*isic*`", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   actual <- rm_na(unique(unnest_product(out)$isic_4digit))

--- a/tests/testthat/test-profile_emissions_upstream.R
+++ b/tests/testthat/test-profile_emissions_upstream.R
@@ -10,7 +10,7 @@ test_that("irrelevant columns in `ecoinvent_inputs` aren't in the output", {
   ecoinvent_inputs$new <- "test"
 
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_emissions_upstream(
     companies,
@@ -19,7 +19,7 @@ test_that("irrelevant columns in `ecoinvent_inputs` aren't in the output", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt = isic_tilt
+    isic = isic
   )
 
   expect_false(hasName(unnest_product(out), "new"))
@@ -35,7 +35,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   # New API
   out <- profile_emissions_upstream(
@@ -45,7 +45,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt = isic_tilt
+    isic = isic
   )
 
   # Old API
@@ -63,7 +63,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     ecoinvent_activities,
     ecoinvent_europages,
     ecoinvent_inputs,
-    isic_tilt
+    isic
   )
 
   out_company <- prepare_ictr_company(
@@ -73,7 +73,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     ecoinvent_activities,
     ecoinvent_europages,
     ecoinvent_inputs,
-    isic_tilt
+    isic
   )
 
   new <- arrange(unnest_product(out), companies_id)
@@ -95,7 +95,7 @@ test_that("the output at product level has columns matching isic and sector", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_emissions_upstream(
     companies,
@@ -104,7 +104,7 @@ test_that("the output at product level has columns matching isic and sector", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt = isic_tilt
+    isic = isic
   )
 
   product <- unnest_product(out)
@@ -123,7 +123,7 @@ test_that("doesn't pad `*isic*`", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_emissions_upstream(
     companies,
@@ -132,7 +132,7 @@ test_that("doesn't pad `*isic*`", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt = isic_tilt
+    isic = isic
   )
 
   actual <- rm_na(unique(unnest_product(out)$input_isic_4digit))

--- a/tests/testthat/test-profile_sector.R
+++ b/tests/testthat/test-profile_sector.R
@@ -9,7 +9,7 @@ test_that("irrelevant columns in europages_companies aren't in the output ", {
 
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_sector(
     companies,
@@ -17,7 +17,7 @@ test_that("irrelevant columns in europages_companies aren't in the output ", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   expect_false(hasName(unnest_product(out), "new"))
@@ -32,7 +32,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   # New API
   out <- profile_sector(
@@ -41,7 +41,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   # Old API
@@ -61,7 +61,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   out_company <- prepare_pstr_company(
@@ -70,7 +70,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   expect_equal(
@@ -91,7 +91,7 @@ test_that("the output at product level has columns matching isic and sector", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_sector(
     companies,
@@ -99,7 +99,7 @@ test_that("the output at product level has columns matching isic and sector", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   product <- unnest_product(out)
@@ -117,7 +117,7 @@ test_that("doesn't pad `*isic*`", {
   europages_companies <- ep_companies |> head(3)
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_sector(
     companies,
@@ -125,7 +125,7 @@ test_that("doesn't pad `*isic*`", {
     europages_companies,
     ecoinvent_activities,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   actual <- rm_na(unique(unnest_product(out)$isic_4digit))

--- a/tests/testthat/test-profile_sector_upstream.R
+++ b/tests/testthat/test-profile_sector_upstream.R
@@ -8,7 +8,7 @@ test_that("characterize columns", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_sector_upstream(
     companies,
@@ -18,7 +18,7 @@ test_that("characterize columns", {
     ecoinvent_activities,
     ecoinvent_inputs,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   expect_snapshot(names(unnest_product(out)))
@@ -36,7 +36,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   # New API
   out <- profile_sector_upstream(
@@ -47,7 +47,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     ecoinvent_activities,
     ecoinvent_inputs,
     ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   # Old API
@@ -66,7 +66,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     ecoinvent_activities,
     ecoinvent_europages,
     ecoinvent_inputs,
-    isic_tilt
+    isic
   )
 
   out_company <- prepare_istr_company(
@@ -76,7 +76,7 @@ test_that("the new API is equivalent to the old API except for extra columns", {
     ecoinvent_activities,
     ecoinvent_europages,
     ecoinvent_inputs,
-    isic_tilt
+    isic
   )
 
   expect_equal(
@@ -99,7 +99,7 @@ test_that("the output at product level has columns matching isic and sector", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_sector_upstream(
     companies,
@@ -109,7 +109,7 @@ test_that("the output at product level has columns matching isic and sector", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   product <- unnest_product(out)
@@ -129,7 +129,7 @@ test_that("doesn't pad `*isic*`", {
   ecoinvent_activities <- ecoinvent_activities |> head(3)
   ecoinvent_europages <- small_matches_mapper |> head(3)
   ecoinvent_inputs <- ecoinvent_inputs |> head(3)
-  isic_tilt <- isic_tilt_mapper |> head(3)
+  isic <- isic_tilt_mapper |> head(3)
 
   out <- profile_sector_upstream(
     companies,
@@ -139,7 +139,7 @@ test_that("doesn't pad `*isic*`", {
     ecoinvent_activities = ecoinvent_activities,
     ecoinvent_inputs = ecoinvent_inputs,
     ecoinvent_europages = ecoinvent_europages,
-    isic_tilt
+    isic
   )
 
   actual <- rm_na(unique(unnest_product(out)$input_isic_4digit))


### PR DESCRIPTION
Closes #104 
Waiting for #112

The change is backward compatible. The old argument `isic_tilt` still works but warns the  user they should use `isic` instead.

Reference: https://lifecycle.r-lib.org/articles/communicate.html#renaming-an-argument


FYI @ysherstyuk @SKruthoff

### reprex

This example shows only one `profile*()` function but the same goes for all.

``` r
library(tiltToyData)
library(readr, warn.conflicts = FALSE)
devtools::load_all()
#> ℹ Loading tiltIndicatorAfter

options(readr.show_col_types = FALSE)

companies <- read_csv(toy_emissions_profile_any_companies())
products <- read_csv(toy_emissions_profile_products())

# New argument `isic`
result <- profile_emissions(
  companies,
  products,
  europages_companies = tiltIndicatorAfter::ep_companies,
  ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
  ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
  isic = tiltIndicatorAfter::isic_tilt_mapper
)

# Old argument `isic_tilt`
result <- profile_emissions(
  companies,
  products,
  europages_companies = tiltIndicatorAfter::ep_companies,
  ecoinvent_activities = tiltIndicatorAfter::ecoinvent_activities,
  ecoinvent_europages = tiltIndicatorAfter::matches_mapper |> head(100),
  isic_tilt = tiltIndicatorAfter::isic_tilt_mapper
)
#> Warning: The `isic_tilt` argument of `profile_emissions()` is deprecated as of
#> tiltIndicatorAfter 0.0.0.9017.
#> ℹ Please use the `isic` argument instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
```

<sup>Created on 2023-12-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests). The existing tests were sufficient to confirm the new argument works as expected, and that the old argument also works but throws a warning. I then refactored the tests code so now there is no warning and no use of the old argument.
