### PR TITLE
Quiet deprecation warning from `toy_emissions_profile*_products()`

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,1 +1,11 @@
 small_matches_mapper <- head(tiltIndicatorAfter::matches_mapper, 100)
+
+toy_emissions_profile_products <- function() {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  tiltToyData::toy_emissions_profile_products()
+}
+
+toy_emissions_profile_upstream_products <- function() {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  tiltToyData::toy_emissions_profile_upstream_products()
+}


### PR DESCRIPTION
Relates to 2DegreesInvesting/tiltToyData#19
Relates to #122

This PR creates a local version of the deprecated `toy_emissions_profile*_products()`. This is to suppress the deprecation warning and reduce the noise during testing.



----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
