### PR TITLE
Setup all tests to read data quietly

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,2 @@
+# https://testthat.r-lib.org/articles/special-files.html#setup-files
+local_options(readr.show_col_types = FALSE, .local_envir = teardown_env())


### PR DESCRIPTION
Setup tests to read data quietly as documented in https://testthat.r-lib.org/articles/special-files.html#setup-files

The goal is to DRY the multiple instances when we use the option `readr.show_col_types = FALSE` -- i.e. to enable #133.

This is pure refactoring.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.
