### PR TITLE
Add `ei_geography` and `input_ei_geography` columns to product level outputs of all four profile indicators

### DIFF
--- a/R/prepare_ictr_product.R
+++ b/R/prepare_ictr_product.R
@@ -28,7 +28,7 @@ prepare_ictr_product <- function(ictr_prod, comp, eco_activities, match_mapper, 
     rename_ictr_product() |>
     mutate(benchmark = ifelse(is.na(.data$ICTR_risk_category), NA, .data$benchmark), .by = c("companies_id")) |>
     select(-c(
-      "matching_certainty_num", "avg_matching_certainty_num", "geography", "extra_rowid"
+      "matching_certainty_num", "avg_matching_certainty_num", "extra_rowid"
     )) |>
     arrange(.data$country) |>
     distinct() |>
@@ -46,7 +46,9 @@ rename_ictr_product <- function(data) {
       ICTR_risk_category = "risk_category",
       input_name = "exchange_name",
       input_unit = "exchange_unit_name",
-      input_isic_4digit_name = "isic_4digit_name_ecoinvent"
+      input_isic_4digit_name = "isic_4digit_name_ecoinvent",
+      ei_geography = "geography",
+      ei_input_geography = "input_geography"
     )
 }
 

--- a/R/prepare_inter_pstr_product.R
+++ b/R/prepare_inter_pstr_product.R
@@ -5,12 +5,10 @@
 #' @return A dataframe that prepares the intermediate output of pstr_product
 #' @noRd
 prepare_inter_pstr_product <- function(pstr_prod, comp, eco_activities, match_mapper, isic_tilt_map) {
-  activities <- eco_activities |>
-    select("activity_uuid_product_uuid", "reference_product_name", "activity_name", "unit")
 
   pstr_prod |>
     left_join(comp, by = "companies_id") |>
-    left_join(activities, by = "activity_uuid_product_uuid") |>
+    left_join(eco_activities, by = "activity_uuid_product_uuid") |>
     left_join(match_mapper, by = c("country", "main_activity", "clustered", "activity_uuid_product_uuid")) |>
     left_join(isic_tilt_map, by = "isic_4digit") |>
     add_avg_matching_certainty("completion") |>

--- a/R/prepare_istr_product.R
+++ b/R/prepare_istr_product.R
@@ -27,7 +27,7 @@ prepare_istr_product <- function(istr_prod, comp, eco_activities, match_mapper, 
     relocate_istr_product() |>
     rename_istr_product() |>
     mutate(scenario = recode(.data$scenario, "1.5c rps" = "IPR 1.5c RPS", "nz 2050" = "WEO NZ 2050")) |>
-    select(-c("matching_certainty_num", "avg_matching_certainty_num", "grouped_by", "type", "geography")) |>
+    select(-c("matching_certainty_num", "avg_matching_certainty_num", "grouped_by", "type")) |>
     distinct() |>
     arrange(.data$country) |>
     rename_118()
@@ -43,7 +43,9 @@ rename_istr_product <- function(data) {
       ISTR_risk_category = "risk_category",
       input_name = "exchange_name",
       input_unit = "exchange_unit_name",
-      input_isic_4digit_name = "isic_4digit_name_ecoinvent"
+      input_isic_4digit_name = "isic_4digit_name_ecoinvent",
+      ei_geography = "geography",
+      ei_input_geography = "input_geography"
     )
 }
 

--- a/R/prepare_pctr_product.R
+++ b/R/prepare_pctr_product.R
@@ -35,7 +35,8 @@ rename_pctr_product <- function(data) {
       benchmark = "grouped_by",
       PCTR_risk_category = "risk_category",
       ep_product = "clustered",
-      isic_4digit_name = "isic_4digit_name_ecoinvent"
+      isic_4digit_name = "isic_4digit_name_ecoinvent",
+      ei_geography = "geography"
     )
 }
 

--- a/R/prepare_pstr_product.R
+++ b/R/prepare_pstr_product.R
@@ -31,7 +31,8 @@ rename_pstr_product <- function(data) {
       matching_certainty_company_average = "avg_matching_certainty",
       PSTR_risk_category = "risk_category",
       ep_product = "clustered",
-      isic_4digit_name = "isic_4digit_name_ecoinvent"
+      isic_4digit_name = "isic_4digit_name_ecoinvent",
+      ei_geography = "geography"
     )
 }
 

--- a/R/select_datasets.R
+++ b/R/select_datasets.R
@@ -17,7 +17,8 @@ select_ecoinvent_inputs <- function(data) {
     select(
       "input_activity_uuid_product_uuid",
       "exchange_name",
-      "exchange_unit_name"
+      "exchange_unit_name",
+      "input_geography"
     ) |>
     distinct()
 }

--- a/tests/testthat/_snaps/profile_emissions.md
+++ b/tests/testthat/_snaps/profile_emissions.md
@@ -14,7 +14,7 @@
       [17] "company_city"                       "postcode"                          
       [19] "address"                            "main_activity"                     
       [21] "activity_uuid_product_uuid"         "reduction_targets"                 
-      [23] "geography"                         
+      [23] "ei_geography"                      
 
 ---
 

--- a/tests/testthat/_snaps/profile_sector_upstream.md
+++ b/tests/testthat/_snaps/profile_sector_upstream.md
@@ -16,7 +16,8 @@
       [21] "address"                            "main_activity"                     
       [23] "activity_uuid_product_uuid"         "reduction_targets"                 
       [25] "input_isic_4digit"                  "sector_scenario"                   
-      [27] "subsector_scenario"                 "input_isic_4digit_name"            
+      [27] "subsector_scenario"                 "ei_input_geography"                
+      [29] "input_isic_4digit_name"             "ei_geography"                      
 
 ---
 

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -127,3 +127,25 @@ test_that("doesn't pad `*isic*`", {
   actual <- rm_na(unique(unnest_product(out)$isic_4digit))
   expect_equal(actual, "1")
 })
+
+test_that("`ei_geography` column is present at product level output", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_emissions_profile_any_companies())
+  co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_emissions(
+    companies,
+    co2,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_europages,
+    isic_name
+  ) |> unnest_product()
+
+  expect_true(all(c("ei_geography") %in% names(out)))
+})

--- a/tests/testthat/test-profile_emissions_upstream.R
+++ b/tests/testthat/test-profile_emissions_upstream.R
@@ -140,3 +140,27 @@ test_that("doesn't pad `*isic*`", {
   actual <- rm_na(unique(unnest_product(out)$input_isic_4digit))
   expect_equal(actual, "1")
 })
+
+test_that("`ei_geography` and `input_ei_grougraphy` columns are present at product level output", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_emissions_profile_any_companies())
+  co2 <- read_csv(toy_emissions_profile_upstream_products_ecoinvent())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_emissions_upstream(
+    companies,
+    co2,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_inputs,
+    ecoinvent_europages,
+    isic_name
+  ) |> unnest_product()
+
+  expect_true(all(c("ei_geography", "ei_input_geography") %in% names(out)))
+})

--- a/tests/testthat/test-profile_sector.R
+++ b/tests/testthat/test-profile_sector.R
@@ -132,3 +132,25 @@ test_that("doesn't pad `*isic*`", {
   actual <- rm_na(unique(unnest_product(out)$isic_4digit))
   expect_equal(actual, "1")
 })
+
+test_that("`ei_geography` column is present at product level output", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_sector_profile_companies())
+  scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_sector(
+    companies,
+    scenarios,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_europages,
+    isic_name
+  ) |> unnest_product()
+
+  expect_true(all(c("ei_geography") %in% names(out)))
+})

--- a/tests/testthat/test-profile_sector_upstream.R
+++ b/tests/testthat/test-profile_sector_upstream.R
@@ -147,3 +147,29 @@ test_that("doesn't pad `*isic*`", {
   actual <- rm_na(unique(unnest_product(out)$input_isic_4digit))
   expect_equal(actual, "1")
 })
+
+test_that("`ei_geography` and `input_ei_grougraphy` columns are present at product level output", {
+  local_options(readr.show_col_types = FALSE)
+
+  companies <- read_csv(toy_sector_profile_upstream_companies())
+  scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  inputs <- read_csv(toy_sector_profile_upstream_products())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_sector_upstream(
+    companies,
+    scenarios,
+    inputs,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_inputs,
+    ecoinvent_europages,
+    isic_name
+  ) |> unnest_product()
+
+  expect_true(all(c("ei_geography", "ei_input_geography") %in% names(out)))
+})


### PR DESCRIPTION
closes #119 

This PR adds `ei_geography` column in `emission_profile` and `sector_profile` at product level, and adds both `ei_geography` and `ei_input_geography` in `emission_profile_upstream` and `sector_profile_upstream` at product level.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
