### PR TITLE
Add `profile_ranking_avg` and `reduction_targets_avg` columns at company level in emission and sector profile indictors repectively

### DIFF
--- a/R/polish_emissions_profile_company.R
+++ b/R/polish_emissions_profile_company.R
@@ -13,6 +13,7 @@ polish_emissions_profile_company <- function(ep_comp, ep_prod, europages_compani
     distinct()
 
   ep_comp |>
+    add_profile_ranking_average(ep_prod) |>
     left_join(inter_result, by = "companies_id", relationship = "many-to-many") |>
     distinct() |>
     rename_emissions_profile_company() |>

--- a/R/polish_emissions_profile_upstream_company.R
+++ b/R/polish_emissions_profile_upstream_company.R
@@ -16,6 +16,7 @@ polish_emissions_profile_upstream_company <- function(epu_comp, epu_prod, europa
     distinct()
 
   epu_comp |>
+    add_profile_ranking_average(epu_prod) |>
     left_join(inter_result, by = "companies_id") |>
     rename_emissions_profile_upstream_company() |>
     # To check: here ICTR_share is used instead of matching_certainty_company_average

--- a/R/polish_sector_profile_company.R
+++ b/R/polish_sector_profile_company.R
@@ -7,7 +7,9 @@
 #' # See examples in `?profile_sector_profile`
 polish_sector_profile_company <- function(sp_comp, sp_prod, europages_companies, ecoinvent_activities, ecoinvent_europages, isic) {
   sp_prod <- sanitize_isic(sp_prod)
-  sp_comp <- sector_profile_any_polish_output_at_company_level(sp_comp)
+  sp_comp <- sp_comp |>
+    add_profile_ranking_average(sp_prod) |>
+    sector_profile_any_polish_output_at_company_level()
 
   inter_result <- prepare_inter_sector_profile(sp_prod, europages_companies, ecoinvent_activities, ecoinvent_europages, isic) |>
     select("companies_id", "company_name", "company_city", "country", "postcode", "address", "main_activity", "avg_matching_certainty") |>
@@ -30,7 +32,8 @@ rename_sector_profile_company <- function(data) {
     rename(
       PSTR_risk_category = "risk_category",
       PSTR_share = "value",
-      matching_certainty_company_average = "avg_matching_certainty"
+      matching_certainty_company_average = "avg_matching_certainty",
+      reduction_targets_avg = "profile_ranking_avg"
     )
 }
 

--- a/R/polish_sector_profile_upstream_company.R
+++ b/R/polish_sector_profile_upstream_company.R
@@ -7,7 +7,9 @@
 #' # See examples in `?profile_sector_upstream`
 polish_sector_profile_upstream_company <- function(spu_comp, spu_prod, europages_companies, ecoinvent_activities, ecoinvent_europages, ecoinvent_inputs, isic) {
   spu_prod <- sanitize_isic(spu_prod)
-  spu_comp <- sector_profile_any_polish_output_at_company_level(spu_comp)
+  spu_comp <- spu_comp |>
+    add_profile_ranking_average(spu_prod) |>
+    sector_profile_any_polish_output_at_company_level()
 
   inter_result <- polish_sector_profile_upstream_product(spu_prod, europages_companies, ecoinvent_activities, ecoinvent_europages, ecoinvent_inputs, isic) |>
     select(
@@ -32,7 +34,8 @@ rename_sector_profile_upstream_company <- function(data) {
   data |>
     rename(
       ISTR_risk_category = "risk_category",
-      ISTR_share = "value"
+      ISTR_share = "value",
+      reduction_targets_avg = "profile_ranking_avg"
     )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,3 +87,14 @@ rename_118 <- function(data) {
       subsector_scenario = "subsector"
     )))
 }
+
+add_profile_ranking_average <- function(data, product) {
+  profile_ranking_average <- product |>
+    select(.data$companies_id, .data$grouped_by, .data$profile_ranking) |>
+    mutate(profile_ranking_avg = round(mean(.data$profile_ranking, na.rm = TRUE), 3),
+           .by = c("companies_id", "grouped_by")) |>
+    select(-c(.data$profile_ranking)) |>
+    distinct()
+
+  data |> left_join(profile_ranking_average, by = c("companies_id", "grouped_by"))
+}

--- a/tests/testthat/_snaps/profile_emissions.md
+++ b/tests/testthat/_snaps/profile_emissions.md
@@ -28,5 +28,5 @@
        [7] "co2e_lower"                         "co2e_upper"                        
        [9] "matching_certainty_company_average" "company_city"                      
       [11] "postcode"                           "address"                           
-      [13] "main_activity"                     
+      [13] "main_activity"                      "profile_ranking_avg"               
 

--- a/tests/testthat/_snaps/profile_sector_upstream.md
+++ b/tests/testthat/_snaps/profile_sector_upstream.md
@@ -30,4 +30,5 @@
        [7] "year"                               "matching_certainty_company_average"
        [9] "company_city"                       "postcode"                          
       [11] "address"                            "main_activity"                     
+      [13] "reduction_targets_avg"             
 

--- a/tests/testthat/test-profile_emissions_upstream.R
+++ b/tests/testthat/test-profile_emissions_upstream.R
@@ -213,3 +213,26 @@ test_that("columns `co2e_lower` and `co2e_upper` give reproducible results after
   expect_equal(product_first, product_second)
   expect_equal(company_first, company_second)
 })
+
+test_that("outputs `profile_ranking_avg` at company level", {
+  companies <- read_csv(toy_emissions_profile_any_companies())
+  co2 <- read_csv(toy_emissions_profile_upstream_products_ecoinvent())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_emissions_upstream(
+    companies,
+    co2,
+    europages_companies = europages_companies,
+    ecoinvent_activities = ecoinvent_activities,
+    ecoinvent_inputs = ecoinvent_inputs,
+    ecoinvent_europages = ecoinvent_europages,
+    isic = isic_name
+  )
+
+  company <- unnest_company(out)
+  expect_true(hasName(company, "profile_ranking_avg"))
+})

--- a/tests/testthat/test-profile_sector.R
+++ b/tests/testthat/test-profile_sector.R
@@ -227,3 +227,24 @@ test_that("yield NA in `*tilt_sector` and `*tilt_subsector` in *profile$ risk co
   these_cols_are_full_of_na <- all(is.na(select(na, tilt_sector, tilt_subsector)))
   expect_true(these_cols_are_full_of_na)
 })
+
+test_that("outputs `profile_ranking_avg` at company level", {
+  companies <- read_csv(toy_sector_profile_companies())
+  scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_sector(
+    companies,
+    scenarios,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_europages,
+    isic_name
+  )
+
+  company <- unnest_company(out)
+  expect_true(hasName(company, "reduction_targets_avg"))
+})

--- a/tests/testthat/test-profile_sector_upstream.R
+++ b/tests/testthat/test-profile_sector_upstream.R
@@ -128,3 +128,27 @@ test_that("total number of rows for a comapny is either 1 or 3", {
   expect_true(all(unique(out$count) %in% c(1, 3)))
 })
 
+test_that("outputs `profile_ranking_avg` at company level", {
+  companies <- read_csv(toy_sector_profile_upstream_companies())
+  scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  inputs <- read_csv(toy_sector_profile_upstream_products())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  isic_name <- read_csv(toy_isic_name())
+
+  out <- profile_sector_upstream(
+    companies,
+    scenarios,
+    inputs,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_inputs,
+    ecoinvent_europages,
+    isic_name
+  )
+
+  company <- unnest_company(out)
+  expect_true(hasName(company, "reduction_targets_avg"))
+})


### PR DESCRIPTION
closes #161 

Dear @AnneSchoenauer @Tilmon @maurolepore,
This PR adds the `profile_ranking_avg` and `reduction_targets_avg` columns at company level in emission and sector profile indictors respectively. The average column is the mean of `profile_ranking` values after grouping the rows based on columns `companies_id` and `group_by`. You can look at a small example using this reprex:

```
library(readr)
library(dplyr)
devtools::load_all(".")
#> ℹ Loading tiltIndicatorAfter
options(width = 500)

local_options(readr.show_col_types = FALSE)
companies <- read_csv(toy_emissions_profile_any_companies()) |>
    filter(companies_id %in% c("nonphilosophical_llama"))
  co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
  europages_companies <- read_csv(toy_europages_companies())
  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
  isic_name <- read_csv(toy_isic_name())

  out <- profile_emissions(
    companies,
    co2,
    europages_companies,
    ecoinvent_activities,
    ecoinvent_europages,
    isic_name
  )

  product <- unnest_product(out) |>
    filter(benchmark == "all")
  company <- unnest_company(out) |>
    filter(benchmark == "all")

product
#> # A tibble: 2 × 7
#>   companies_id           grouped_by risk_category profile_ranking clustered                   activity_uuid_product_uuid           co2_footprint
#>   <chr>                  <chr>      <chr>                   <dbl> <chr>                       <chr>                                        <dbl>
#> 1 nonphilosophical_llama all        low                     0.32 surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693
#> 2 nonphilosophical_llama all        low                     0.34 surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693

company
#> # A tibble: 3 × 5
#>   companies_id           grouped_by risk_category value profile_ranking_avg
#>   <chr>                  <chr>      <chr>         <dbl>               <dbl>
#> 1 nonphilosophical_llama all        high              0               0.33
#> 2 nonphilosophical_llama all        medium            0               0.33
#> 3 nonphilosophical_llama all        low               1               0.33

```

Please do not get misled by the `0.33` values in risk category high and medium. As you can see that the `low` risk category will have the average value of `0.33` from values `0.32` and `0.34`.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
