### PR TITLE
Update documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,5 +41,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 BugReports: https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues

--- a/R/profile_emissions_upstream.R
+++ b/R/profile_emissions_upstream.R
@@ -23,7 +23,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_emissions_profile_any_companies())
-#' products <- read_csv(toy_emissions_profile_products())
+#' products <- read_csv(toy_emissions_profile_products_ecoinvent())
 #' europages_companies <- read_csv(toy_europages_companies())
 #' ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
 #' ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
@@ -44,7 +44,7 @@
 #'
 #'
 #'
-#' inputs <- read_csv(toy_emissions_profile_upstream_products())
+#' inputs <- read_csv(toy_emissions_profile_upstream_products_ecoinvent())
 #' ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
 #'
 #' result <- profile_emissions_upstream(

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -66,7 +66,7 @@ library(readr, warn.conflicts = FALSE)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_emissions_profile_products())
+products <- read_csv(toy_emissions_profile_products_ecoinvent())
 europages_companies <- read_csv(toy_europages_companies())
 ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
 ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
@@ -87,7 +87,7 @@ result |> unnest_company()
 
 
 
-inputs <- read_csv(toy_emissions_profile_upstream_products())
+inputs <- read_csv(toy_emissions_profile_upstream_products_ecoinvent())
 ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
 
 result <- profile_emissions_upstream(


### PR DESCRIPTION
Maybe relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/163

I suspect the failing check in #163 might be related to the difference between the documentation of tiltIndicatorAfter and tiltWorkflows. The one in tiltWorkflows updates automatically with changes in tiltIndicatorAfter but we first need to redocument from tiltWorkflows. 

- Update roxygen2
- Update documentation


----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
