### PR TITLE
Remove warnings that clutter test results

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -90,10 +90,10 @@ rename_118 <- function(data) {
 
 add_profile_ranking_average <- function(data, product) {
   profile_ranking_average <- product |>
-    select(.data$companies_id, .data$grouped_by, .data$profile_ranking) |>
+    select("companies_id", "grouped_by", "profile_ranking") |>
     mutate(profile_ranking_avg = round(mean(.data$profile_ranking, na.rm = TRUE), 3),
            .by = c("companies_id", "grouped_by")) |>
-    select(-c(.data$profile_ranking)) |>
+    select(-c("profile_ranking")) |>
     distinct()
 
   data |> left_join(profile_ranking_average, by = c("companies_id", "grouped_by"))


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/164

This PR removes 228 warnings that clutter test results and obscure other important notifications.

### Details

cbd0ae40 introduced a deprecated usage of a tidyselect expression:

```
cbd0ae40 (Kalash Singhal 2024-02-27 07:46:07 +0100  93)     select(.data$companies_id, .data$grouped_by, .data$profile_ranking) |>
```

That yields 228 warnings:

```
══ Results ════════════════════════════════════════════════════════════════════════════════
Duration: 54.4 s

[ FAIL 0 | WARN 228 | SKIP 0 | PASS 79 ]
```

For example:

```
Warning (test-utils.R:61:3): rename_118() function is not applied if issue #118 is not addressed
Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0.
i Please use `"profile_ranking"` instead of `.data$profile_ranking`
```

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
