### PR TITLE
Remove an empty section from the website's Reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -7,9 +7,3 @@ reference:
   - title: Main functions
     contents:
       - has_concept("top-level functions")
-
-  - title: Datasets from tiltIndicator
-    desc: This datasets will be retired. Intead see the package tiltToyData.
-    contents:
-      - matches("..tr_")
-      - -matches("prepare_")


### PR DESCRIPTION
Relates to #160

This PR removes the needless section from the website's reference.

Before

![image](https://github.com/2DegreesInvesting/tiltIndicatorAfter/assets/5856545/8af7926e-dab0-478e-ba90-cdb7b8afc849)


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
