### PR TITLE
At company level `profile_emissions()` can optionally output `co2_avg`

### DIFF
--- a/R/profile_emissions.R
+++ b/R/profile_emissions.R
@@ -33,5 +33,5 @@ profile_emissions <- function(companies,
     isic
   )
   exec_profile("emissions_profile", indicator, indicator_after) |>
-    may_add_co2_footprint(select(co2, matches(c("_uuid", "co2_footprint"))))
+    may_add_licensed_co2_columns(select(co2, matches(c("_uuid", "co2_footprint"))))
 }

--- a/R/profile_emissions.R
+++ b/R/profile_emissions.R
@@ -33,5 +33,5 @@ profile_emissions <- function(companies,
     isic
   )
   exec_profile("emissions_profile", indicator, indicator_after) |>
-    may_add_licensed_co2_columns(select(co2, matches(c("_uuid", "co2_footprint"))))
+    optionally_output_co2_footprint(select(co2, matches(c("_uuid", "co2_footprint"))))
 }

--- a/R/profile_emissions.R
+++ b/R/profile_emissions.R
@@ -35,4 +35,3 @@ profile_emissions <- function(companies,
   exec_profile("emissions_profile", indicator, indicator_after) |>
     may_add_co2_footprint(select(co2, matches(c("_uuid", "co2_footprint"))))
 }
-

--- a/R/profile_emissions.R
+++ b/R/profile_emissions.R
@@ -35,3 +35,4 @@ profile_emissions <- function(companies,
   exec_profile("emissions_profile", indicator, indicator_after) |>
     may_add_co2_footprint(select(co2, matches(c("_uuid", "co2_footprint"))))
 }
+

--- a/R/tiltIndicatorAfter-options.R
+++ b/R/tiltIndicatorAfter-options.R
@@ -70,4 +70,3 @@ co2_keep_licensed_footprint <- function() {
 verbose <- function() {
   getOption("tiltIndicatorAfter.verbose", default = TRUE)
 }
-

--- a/R/tiltIndicatorAfter-options.R
+++ b/R/tiltIndicatorAfter-options.R
@@ -70,3 +70,4 @@ co2_keep_licensed_footprint <- function() {
 verbose <- function() {
   getOption("tiltIndicatorAfter.verbose", default = TRUE)
 }
+

--- a/R/tiltIndicatorAfter-options.R
+++ b/R/tiltIndicatorAfter-options.R
@@ -7,8 +7,10 @@
 #' in the `co2*` columns.
 #' * `tiltIndicatorAfter.co2_keep_licensed_min_max`: Keeps the licensed `min`
 #' and `max` columns that yield the noisy `co2*` columns.
-#' * `tiltIndicatorAfter.co2_keep_licensed_footprint`: Keeps the licensed
-#' `co2_footprint` column.
+#' * `tiltIndicatorAfter.output_co2_footprint`:
+#'     * At product level it outputs licensed column `co2_footprint`.
+#'     * At company level it outputs the column `co2_avg` (average `co2_footprint`
+#'     by `companies_id`).
 #' * `tiltIndicatorAfter.verbose`: Controls verbosity.
 #'
 #' @keywords internal
@@ -63,8 +65,8 @@ co2_keep_licensed_min_max <- function() {
   getOption("tiltIndicatorAfter.co2_keep_licensed_min_max", default = FALSE)
 }
 
-co2_keep_licensed_footprint <- function() {
-  getOption("tiltIndicatorAfter.co2_keep_licensed_footprint", default = FALSE)
+output_co2_footprint <- function() {
+  getOption("tiltIndicatorAfter.output_co2_footprint", default = FALSE)
 }
 
 verbose <- function() {

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -40,8 +40,7 @@ may_add_co2_footprint <- function(out, co2_footprint) {
       unnest_product() |>
       left_join(
         co2_footprint,
-        by = "activity_uuid_product_uuid",
-        relationship = "many-to-many"
+        by = "activity_uuid_product_uuid"
       )
 
     co2_avg <- product |>
@@ -52,7 +51,7 @@ may_add_co2_footprint <- function(out, co2_footprint) {
       )
     company <- out |>
       unnest_company() |>
-      left_join(co2_avg, by = "companies_id")
+      left_join(co2_avg, by = "companies_id", relationship = "many-to-many")
 
     out <- nest_levels(product, company)
   }

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -42,7 +42,7 @@ may_add_co2_footprint <- function(out, co2_footprint) {
 
     co2_avg <- product |>
       select("companies_id", "co2_footprint") |>
-      dplyr::summarize(co2_avg = mean(co2_footprint, na.rm = TRUE), .by = "companies_id")
+      summarise(co2_avg = mean(co2_footprint, na.rm = TRUE), .by = "companies_id")
     company <- out |>
       unnest_company() |>
       left_join(co2_avg, by = "companies_id")

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -34,7 +34,7 @@ inform_mean_percent_noise <- function(data) {
   invisible(data)
 }
 
-may_add_licensed_co2_columns <- function(out, co2_footprint) {
+optionally_output_co2_footprint <- function(out, co2_footprint) {
   if (!output_co2_footprint()) {
     return(out)
   }

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -43,15 +43,13 @@ may_add_co2_footprint <- function(out, co2_footprint) {
         by = "activity_uuid_product_uuid"
       )
 
+    by <- c("companies_id", "benchmark")
     co2_avg <- product |>
-      select("companies_id", "benchmark", "co2_footprint") |>
-      summarise(
-        co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3),
-        .by = c("companies_id", "benchmark")
-      )
+      select(all_of(c(by, "co2_footprint"))) |>
+      summarise(co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3), .by = by)
     company <- out |>
       unnest_company() |>
-      left_join(co2_avg, by = "companies_id", relationship = "many-to-many")
+      left_join(co2_avg, by = by, relationship = "many-to-many")
 
     out <- nest_levels(product, company)
   }

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -39,7 +39,14 @@ may_add_co2_footprint <- function(out, co2_footprint) {
     product <- out |>
       unnest_product() |>
       left_join(co2_footprint, by = "activity_uuid_product_uuid")
-    company <- out |> unnest_company()
+
+    co2_avg <- product |>
+      select("companies_id", "co2_footprint") |>
+      dplyr::summarize(co2_avg = mean(co2_footprint, na.rm = TRUE) , .by = "companies_id")
+    company <- out |>
+      unnest_company() |>
+      left_join(co2_avg, by = "companies_id")
+
     out <- nest_levels(product, company)
   }
   out

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -46,7 +46,10 @@ may_add_licensed_co2_columns <- function(out, co2_footprint) {
     by <- c("companies_id", "benchmark")
     co2_avg <- product |>
       select(all_of(c(by, "co2_footprint"))) |>
-      summarise(co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3), .by = by)
+      summarise(
+        co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3),
+        .by = all_of(by)
+      )
     company <- out |>
       unnest_company() |>
       left_join(co2_avg, by = by, relationship = "many-to-many")

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -38,7 +38,11 @@ may_add_co2_footprint <- function(out, co2_footprint) {
   if (co2_keep_licensed_footprint()) {
     product <- out |>
       unnest_product() |>
-      left_join(co2_footprint, by = "activity_uuid_product_uuid")
+      left_join(
+        co2_footprint,
+        by = "activity_uuid_product_uuid",
+        relationship = "many-to-many"
+      )
 
     co2_avg <- product |>
       select("companies_id", "benchmark", "co2_footprint") |>

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -34,8 +34,8 @@ inform_mean_percent_noise <- function(data) {
   invisible(data)
 }
 
-may_add_co2_footprint <- function(out, co2_footprint) {
-  if (co2_keep_licensed_footprint()) {
+may_add_licensed_co2_columns <- function(out, co2_footprint) {
+  if (output_co2_footprint()) {
     product <- out |>
       unnest_product() |>
       left_join(

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -42,7 +42,7 @@ may_add_co2_footprint <- function(out, co2_footprint) {
 
     co2_avg <- product |>
       select("companies_id", "co2_footprint") |>
-      dplyr::summarize(co2_avg = mean(co2_footprint, na.rm = TRUE) , .by = "companies_id")
+      dplyr::summarize(co2_avg = mean(co2_footprint, na.rm = TRUE), .by = "companies_id")
     company <- out |>
       unnest_company() |>
       left_join(co2_avg, by = "companies_id")

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -35,27 +35,27 @@ inform_mean_percent_noise <- function(data) {
 }
 
 may_add_licensed_co2_columns <- function(out, co2_footprint) {
-  if (output_co2_footprint()) {
-    product <- out |>
-      unnest_product() |>
-      left_join(
-        co2_footprint,
-        by = "activity_uuid_product_uuid"
-      )
-
-    by <- c("companies_id", "benchmark")
-    co2_avg <- product |>
-      select(all_of(c(by, "co2_footprint"))) |>
-      summarise(
-        co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3),
-        .by = all_of(by)
-      )
-    company <- out |>
-      unnest_company() |>
-      left_join(co2_avg, by = by, relationship = "many-to-many")
-
-    out <- nest_levels(product, company)
+  if (!output_co2_footprint()) {
+    return(out)
   }
 
-  out
+  product <- out |>
+    unnest_product() |>
+    left_join(
+      co2_footprint,
+      by = "activity_uuid_product_uuid"
+    )
+
+  by <- c("companies_id", "benchmark")
+  co2_avg <- product |>
+    select(all_of(c(by, "co2_footprint"))) |>
+    summarise(
+      co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3),
+      .by = all_of(by)
+    )
+  company <- out |>
+    unnest_company() |>
+    left_join(co2_avg, by = by, relationship = "many-to-many")
+
+  nest_levels(product, company)
 }

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -41,8 +41,11 @@ may_add_co2_footprint <- function(out, co2_footprint) {
       left_join(co2_footprint, by = "activity_uuid_product_uuid")
 
     co2_avg <- product |>
-      select("companies_id", "co2_footprint") |>
-      summarise(co2_avg = mean(co2_footprint, na.rm = TRUE), .by = "companies_id")
+      select("companies_id", "benchmark", "co2_footprint") |>
+      summarise(
+        co2_avg = round(mean(co2_footprint, na.rm = TRUE), 3),
+        .by = c("companies_id", "benchmark")
+      )
     company <- out |>
       unnest_company() |>
       left_join(co2_avg, by = "companies_id")

--- a/man/tiltIndicatorAfter_options.Rd
+++ b/man/tiltIndicatorAfter_options.Rd
@@ -11,8 +11,12 @@ testing the code or creating data:
 in the \verb{co2*} columns.
 \item \code{tiltIndicatorAfter.co2_keep_licensed_min_max}: Keeps the licensed \code{min}
 and \code{max} columns that yield the noisy \verb{co2*} columns.
-\item \code{tiltIndicatorAfter.co2_keep_licensed_footprint}: Keeps the licensed
-\code{co2_footprint} column.
+\item \code{tiltIndicatorAfter.output_co2_footprint}:
+\itemize{
+\item At product level it outputs licensed column \code{co2_footprint}.
+\item At company level it outputs the column \code{co2_avg} (average \code{co2_footprint}
+by \code{companies_id}).
+}
 \item \code{tiltIndicatorAfter.verbose}: Controls verbosity.
 }
 }

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -385,7 +385,7 @@ test_that("can optionally output `co2_footprint` at product level", {
   ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
   isic_name <- read_csv(toy_isic_name())
 
-  local_options(tiltIndicatorAfter.co2_keep_licensed_footprint = TRUE)
+  local_options(tiltIndicatorAfter.output_co2_footprint = TRUE)
   out <- profile_emissions(
     companies,
     co2,
@@ -406,7 +406,7 @@ test_that("can optionally output `co2_avg` at company level", {
   ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
   isic_name <- read_csv(toy_isic_name())
 
-  local_options(tiltIndicatorAfter.co2_keep_licensed_footprint = TRUE)
+  local_options(tiltIndicatorAfter.output_co2_footprint = TRUE)
   out <- profile_emissions(
     companies,
     co2,

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -398,6 +398,27 @@ test_that("allows yielding the licensed `co2_footprint` column at product level"
   expect_true(hasName(unnest_product(out), "co2_footprint"))
 })
 
+test_that("can optionally output `co2_avg` at company level", {
+  companies <- read_csv(toy_emissions_profile_any_companies())
+  co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  isic_name <- read_csv(toy_isic_name())
+
+  local_options(tiltIndicatorAfter.co2_keep_licensed_footprint = TRUE)
+  out <- profile_emissions(
+    companies,
+    co2,
+    europages_companies,
+    ecoinvent_activities,
+    ecoinvent_europages,
+    isic_name
+  )
+
+  expect_true(hasName(unnest_product(out), "co2_avg"))
+})
+
 test_that("outputs `profile_ranking_avg` at company level", {
   companies <- read_csv(toy_emissions_profile_any_companies())
   co2 <- read_csv(toy_emissions_profile_products_ecoinvent())

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -399,7 +399,8 @@ test_that("allows yielding the licensed `co2_footprint` column at product level"
 })
 
 test_that("can optionally output `co2_avg` at company level", {
-  companies <- read_csv(toy_emissions_profile_any_companies())
+  companies <- read_csv(toy_emissions_profile_any_companies()) |>
+    head(1)
   co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
   europages_companies <- read_csv(toy_europages_companies())
   ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
@@ -416,7 +417,7 @@ test_that("can optionally output `co2_avg` at company level", {
     isic_name
   )
 
-  expect_true(hasName(unnest_product(out), "co2_avg"))
+  expect_true(hasName(unnest_company(out), "co2_avg"))
 })
 
 test_that("outputs `profile_ranking_avg` at company level", {

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -399,8 +399,7 @@ test_that("allows yielding the licensed `co2_footprint` column at product level"
 })
 
 test_that("can optionally output `co2_avg` at company level", {
-  companies <- read_csv(toy_emissions_profile_any_companies()) |>
-    head(1)
+  companies <- read_csv(toy_emissions_profile_any_companies())
   co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
   europages_companies <- read_csv(toy_europages_companies())
   ecoinvent_activities <- read_csv(toy_ecoinvent_activities())


### PR DESCRIPTION
Closes #185 
Extends #184

This PR focuses on the output of `profile_emissions()` at company level. It uses an option to allow licensed users to include the new column `co2_avg`  -- which is the mean of the licensed `co2_footprint` available at product level via the same option.

@AnneSchoenauer please see this reprex and confirm this is what you want.


<details/>
<summary/>
reprex
</summary>

``` r
library(readr, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(withr)
devtools::load_all()
#> ℹ Loading tiltIndicatorAfter
local_options(readr.show_col_types = FALSE)

companies <- read_csv(toy_emissions_profile_any_companies())
co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
europages_companies <- read_csv(toy_europages_companies())
ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
isic_name <- read_csv(toy_isic_name())

before <- profile_emissions(
  companies,
  co2,
  europages_companies,
  ecoinvent_activities,
  ecoinvent_europages,
  isic_name
)
#> ℹ Adding 48% and 87% noise to `co2e_lower` and `co2e_upper`, respectively.

local_options(tiltIndicatorAfter.output_co2_footprint = TRUE)
now <- profile_emissions(
  companies,
  co2,
  europages_companies,
  ecoinvent_activities,
  ecoinvent_europages,
  isic_name
)
#> ℹ Adding 32% and 83% noise to `co2e_lower` and `co2e_upper`, respectively.



# Before the output at company level did NOT have the column `co2_avg`
try({
  company_level <- before |> 
    unnest_company() |> 
    relocate("co2_avg")
})
#> Error in relocate(unnest_company(before), "co2_avg") : 
#>   Can't subset columns that don't exist.
#> ✖ Column `co2_avg` doesn't exist.

# Now the output at company level can optionally have the column `co2_avg`
company_level <- now |> 
  unnest_company() |> 
  relocate("co2_avg")

company_level |> 
  relocate(companies_id, benchmark, co2_avg)
#> # A tibble: 1,728 × 15
#>    companies_id    benchmark co2_avg company_name country emission_profile_share
#>    <chr>           <chr>       <dbl> <chr>        <chr>                    <dbl>
#>  1 asteria_megalo… all          303. asteria_meg… austria                      1
#>  2 asteria_megalo… all          303. asteria_meg… austria                      0
#>  3 asteria_megalo… all          303. asteria_meg… austria                      0
#>  4 asteria_megalo… all          303. asteria_meg… austria                      0
#>  5 asteria_megalo… isic_4di…    303. asteria_meg… austria                      1
#>  6 asteria_megalo… isic_4di…    303. asteria_meg… austria                      0
#>  7 asteria_megalo… isic_4di…    303. asteria_meg… austria                      0
#>  8 asteria_megalo… isic_4di…    303. asteria_meg… austria                      0
#>  9 asteria_megalo… tilt_sec…    303. asteria_meg… austria                      1
#> 10 asteria_megalo… tilt_sec…    303. asteria_meg… austria                      0
#> # ℹ 1,718 more rows
#> # ℹ 9 more variables: emission_profile <chr>, co2e_lower <dbl>,
#> #   co2e_upper <dbl>, matching_certainty_company_average <chr>,
#> #   company_city <chr>, postcode <chr>, address <chr>, main_activity <chr>,
#> #   profile_ranking_avg <dbl>

# It's implemented as you requested: Following Kalash's implementation of
# `profile_ranking_avg`: https://github.com/2DegreesInvesting/tiltIndicatorAfter/blob/main/R/utils.R#L95
# Properties:
# * Computes the mean removing `NA`s.
# * Rounds to 3 decimal places.
# * Groups by `companies_id` and `benchmark` (equivalent to `grouped_by`)
company_level |> 
  distinct(companies_id, benchmark, co2_avg) |> 
  arrange(companies_id)
#> # A tibble: 432 × 3
#>    companies_id                      benchmark        co2_avg
#>    <chr>                             <chr>              <dbl>
#>  1 angular_oregonsilverspotbutterfly all                 303.
#>  2 angular_oregonsilverspotbutterfly isic_4digit         303.
#>  3 angular_oregonsilverspotbutterfly tilt_sector         303.
#>  4 angular_oregonsilverspotbutterfly unit                303.
#>  5 angular_oregonsilverspotbutterfly unit_isic_4digit    303.
#>  6 angular_oregonsilverspotbutterfly unit_tilt_sector    303.
#>  7 animalistic_grub                  all                 303.
#>  8 animalistic_grub                  isic_4digit         303.
#>  9 animalistic_grub                  tilt_sector         303.
#> 10 animalistic_grub                  unit                303.
#> # ℹ 422 more rows

# WARNING: I don't see any variation across benchmarks, i.e. grouping by 
# benchmark seems to have no effect. This may be because of the nature of the
# toy data or because of a bug -- in any case it seems relatively harmless.

# I do see variation across companies, so grouping by companies_id is useful
company_level |> 
  distinct(companies_id, co2_avg) |> 
  arrange(companies_id)
#> # A tibble: 72 × 2
#>    companies_id                       co2_avg
#>    <chr>                                <dbl>
#>  1 angular_oregonsilverspotbutterfly    303. 
#>  2 animalistic_grub                     303. 
#>  3 antimonarchy_canine                  303. 
#>  4 armourpiercing_arawana               303. 
#>  5 arthrodic_harborporpoise              10.4
#>  6 asteria_megalotomusquinquespinosus   303. 
#>  7 automotive_alaskanmalamute           303. 
#>  8 bacciform_mockingbird                 10.4
#>  9 baldish_anemoneshrimp                303. 
#> 10 baldish_jumpingbean                  303. 
#> # ℹ 62 more rows



# Let's first understand how many products are there for each company in the 
# `companies` dataset and in the output at product level

# In the `companies` dataset, most companies have only one product
companies |>
  count(companies_id, activity_uuid_product_uuid) |> 
  filter(n <= 1) |> 
  nrow()
#> [1] 68

# In the `companies` dataset, only a few companies have more than 1 product
companies |>
  count(companies_id, activity_uuid_product_uuid) |> 
  filter(n > 1) |> 
  nrow()
#> [1] 4

# In the output at product level, no company has more than 1 product (i.e. none 
# matched more than one product)
now |> 
  unnest_product() |> 
  distinct(companies_id, activity_uuid_product_uuid) |> 
  count(companies_id, activity_uuid_product_uuid) |> 
  filter(n > 1)
#> # A tibble: 0 × 3
#> # ℹ 3 variables: companies_id <chr>, activity_uuid_product_uuid <chr>, n <int>



# Because each company has a single product, the `co2_footprint` is identical
# to the mean of the `co2_footprint`
now |> 
  unnest_product() |> 
  select(matches(c("id", "co2_footprint"))) |> 
  distinct() |> 
  mutate(
    co2_avg = mean(co2_footprint, na.rm = TRUE), 
    is_identical = identical(co2_footprint, co2_avg),
    .by = "companies_id"
  ) |> 
  print(n = Inf)
#> # A tibble: 72 × 5
#>    companies_id        activity_uuid_produc…¹ co2_footprint co2_avg is_identical
#>    <chr>               <chr>                          <dbl>   <dbl> <lgl>       
#>  1 asteria_megalotomu… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  2 skarn_gallinule     76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  3 relegable_southern… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  4 psychodelic_aireda… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  5 ergophilic_fieldsp… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  6 preexistent_africa… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  7 wealthy_ocelot      76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  8 fulltime_mollusk    76269c17-78d6-420b-99…       303.    303.    TRUE        
#>  9 gentlemanlike_asia… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 10 frowsy_metalmarkbu… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 11 spectacular_americ… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 12 subdermal_chipmunk  76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 13 crowning_wildebeast 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 14 antimonarchy_canine 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 15 nonphilosophical_l… 833caa78-30df-4374-90…         0.693   0.693 TRUE        
#> 16 quasifaithful_amph… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 17 contrite_silkworm   76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 18 harmless_owlbutter… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 19 fascist_maiasaura   76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 20 ironhearted_tarpan  bf94b5a7-b7a2-46d1-bb…        10.4    10.4   TRUE        
#> 21 leathery_acornwood… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 22 automotive_alaskan… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 23 weatherproof_roadr… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 24 springloaded_newt   76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 25 comely_manta        76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 26 unpurified_acornwe… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 27 warriorlike_graysq… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 28 corrosive_nutcrack… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 29 exportable_widgeon  76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 30 reversible_affenpi… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 31 baldish_anemoneshr… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 32 fellow_bovine       76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 33 armourpiercing_ara… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 34 angular_oregonsilv… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 35 twill_norwayrat     76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 36 choppy_mongoose     76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 37 seismological_blac… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 38 feedable_shrew      76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 39 bacciform_mockingb… bf94b5a7-b7a2-46d1-bb…        10.4    10.4   TRUE        
#> 40 equipable_pinemart… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 41 cranky_milksnake    76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 42 melting_auklet      76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 43 lowborn_arcticduck  76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 44 dystopic_kingbird   76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 45 heliophobic_clowna… 833caa78-30df-4374-90…         0.693   0.693 TRUE        
#> 46 unemployed_asiatic… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 47 erectable_watussi   76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 48 lexicologic_americ… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 49 unsafe_atlanticsha… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 50 nondeadly_vixen     76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 51 baldish_jumpingbean 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 52 versicolor_asiantr… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 53 exquisite_englishp… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 54 bereft_anchovy      76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 55 arthrodic_harborpo… bf94b5a7-b7a2-46d1-bb…        10.4    10.4   TRUE        
#> 56 cuboid_noctule      76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 57 private_arrowana    76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 58 elementary_xantusm… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 59 carbonless_dwarfra… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 60 equilibristic_wall… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 61 graphicial_yellowj… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 62 endodermic_izuthru… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 63 chronographic_army… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 64 subzero_whiteeye    76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 65 insecticidal_clown… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 66 griffinesque_eagle  76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 67 animalistic_grub    76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 68 complexionless_gec… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 69 celestial_lovebird  76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 70 charismatic_island… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 71 wingless_northernp… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> 72 epitaphic_yellowha… 76269c17-78d6-420b-99…       303.    303.    TRUE        
#> # ℹ abbreviated name: ¹​activity_uuid_product_uuid
```

</details>



No need to do a technical review of the [Files changed](https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/186/files). I'll merge only with your conceptual confirmation.

@kalashsinghal may choose to see what I did and request changes later.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
