### PR TITLE
`profile_emissions()` now preserves unmatched products

### DIFF
--- a/R/prepare_inter_emissions_profile.R
+++ b/R/prepare_inter_emissions_profile.R
@@ -14,7 +14,4 @@ prepare_inter_emissions_profile <- function(ep_prod, europages_companies, ecoinv
     left_join(prepared_match_mapper, by = join_by_shared_cols_quietly) |>
     left_join(isic, by = "isic_4digit") |>
     add_avg_matching_certainty("completion")
-
-  # |>
-  #   exclude_rows("risk_category")
 }

--- a/R/prepare_inter_emissions_profile.R
+++ b/R/prepare_inter_emissions_profile.R
@@ -13,6 +13,8 @@ prepare_inter_emissions_profile <- function(ep_prod, europages_companies, ecoinv
   ep_product_europages |>
     left_join(prepared_match_mapper, by = join_by_shared_cols_quietly) |>
     left_join(isic, by = "isic_4digit") |>
-    add_avg_matching_certainty("completion") |>
-    exclude_rows("risk_category")
+    add_avg_matching_certainty("completion")
+
+  # |>
+  #   exclude_rows("risk_category")
 }


### PR DESCRIPTION
* Relates to #153 

In tiltIndicator "the `emissions*()` functions preserve unmatched products ([changelog](https://2degreesinvesting.github.io/tiltIndicator/news/index.html#tiltindicator-0009209)). I expected tiltIndicatorAfter to also preserve the "unmatched" products but instead it drops them:
<details/>
<summary/>
reprex
</summary>

``` r
library(dplyr, warn.conflicts = FALSE)
library(readr, warn.conflicts = FALSE)
library(tiltToyData)
library(tiltIndicator)
library(tiltIndicatorAfter)
withr::local_options(readr.show_col_types = FALSE)

packageVersion("tiltIndicator")
#> [1] '0.0.0.9211'
packageVersion("tiltIndicatorAfter")
#> [1] '0.0.0.9023'

# Create small toy data
companies <- read_csv(toy_emissions_profile_any_companies())
id <- unique(companies$companies_id)[[1]]
uuid <- unique(companies$activity_uuid_product_uuid)[[1]]
companies <- companies |>
  filter(companies_id == id) |>
  filter(activity_uuid_product_uuid == uuid)
companies <- bind_rows(companies, companies)
companies[1, "activity_uuid_product_uuid"] <- "unmatched"

co2 <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
  filter(activity_uuid_product_uuid == uuid)

europages_companies <- read_csv(toy_europages_companies()) |>
  filter(companies_id == id)

ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |>
  filter(activity_uuid_product_uuid == uuid)

ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |>
  filter(activity_uuid_product_uuid == uuid)

isic_name <- read_csv(toy_isic_name()) |>
  filter(isic_4digit == co2$isic_4digit)

companies
#> # A tibble: 2 × 7
#>   activity_uuid_product_uuid     clustered companies_id country ei_activity_name
#>   <chr>                          <chr>     <chr>        <chr>   <chr>           
#> 1 unmatched                      tent      antimonarch… germany market for shed…
#> 2 76269c17-78d6-420b-991a-aa38c… tent      antimonarch… germany market for shed…
#> # ℹ 2 more variables: main_activity <chr>, unit <chr>

co2
#> # A tibble: 1 × 8
#>   activity_uuid_produc…¹ co2_footprint ei_activity_name ei_geography isic_4digit
#>   <chr>                          <dbl> <chr>            <chr>        <chr>      
#> 1 76269c17-78d6-420b-99…          303. market for shed… GLO          '4100'     
#> # ℹ abbreviated name: ¹​activity_uuid_product_uuid
#> # ℹ 3 more variables: tilt_sector <chr>, tilt_subsector <chr>, unit <chr>

europages_companies
#> # A tibble: 1 × 8
#>   companies_id  company_name country company_city postcode address main_activity
#>   <chr>         <chr>        <chr>   <chr>        <chr>    <chr>   <chr>        
#> 1 antimonarchy… antimonarch… germany hamburg      22525    schnac… distributor  
#> # ℹ 1 more variable: clustered <chr>

ecoinvent_activities
#> # A tibble: 1 × 5
#>   activity_uuid_product_u…¹ activity_name geography reference_product_name unit 
#>   <chr>                     <chr>         <chr>     <chr>                  <chr>
#> 1 76269c17-78d6-420b-991a-… market for s… tilt_wor… shed, large, wood, no… m2   
#> # ℹ abbreviated name: ¹​activity_uuid_product_uuid

ecoinvent_europages
#> # A tibble: 26 × 6
#>    country main_activity clustered activity_uuid_produc…¹ multi_match completion
#>    <chr>   <chr>         <chr>     <chr>                  <lgl>       <chr>     
#>  1 austria distributor   tent      76269c17-78d6-420b-99… FALSE       low       
#>  2 austria wholesaler    tent      76269c17-78d6-420b-99… FALSE       low       
#>  3 nether… retailer      tent      76269c17-78d6-420b-99… FALSE       low       
#>  4 germany wholesaler    tent      76269c17-78d6-420b-99… FALSE       low       
#>  5 germany distributor   tent      76269c17-78d6-420b-99… FALSE       low       
#>  6 austria wholesaler    sheds, c… 76269c17-78d6-420b-99… FALSE       low       
#>  7 nether… distributor   prefabri… 76269c17-78d6-420b-99… FALSE       low       
#>  8 nether… wholesaler    prefabri… 76269c17-78d6-420b-99… FALSE       low       
#>  9 spain   distributor   prefabri… 76269c17-78d6-420b-99… FALSE       low       
#> 10 nether… retailer      porches,… 76269c17-78d6-420b-99… FALSE       low       
#> # ℹ 16 more rows
#> # ℹ abbreviated name: ¹​activity_uuid_product_uuid

isic_name
#> # A tibble: 1 × 2
#>   isic_4digit isic_4digit_name_ecoinvent
#>   <chr>       <chr>                     
#> 1 '4100'      Construction of buildings



# tiltIndicator preserves unmatched products
tiltIndicator::emissions_profile(companies, co2) |> 
  unnest_product() |> 
  relocate(matches("uuid"))
#> # A tibble: 7 × 7
#>   activity_uuid_product_…¹ companies_id grouped_by risk_category profile_ranking
#>   <chr>                    <chr>        <chr>      <chr>                   <dbl>
#> 1 unmatched                antimonarch… <NA>       <NA>                       NA
#> 2 76269c17-78d6-420b-991a… antimonarch… all        high                        1
#> 3 76269c17-78d6-420b-991a… antimonarch… isic_4dig… high                        1
#> 4 76269c17-78d6-420b-991a… antimonarch… tilt_sect… high                        1
#> 5 76269c17-78d6-420b-991a… antimonarch… unit       high                        1
#> 6 76269c17-78d6-420b-991a… antimonarch… unit_isic… high                        1
#> 7 76269c17-78d6-420b-991a… antimonarch… unit_tilt… high                        1
#> # ℹ abbreviated name: ¹​activity_uuid_product_uuid
#> # ℹ 2 more variables: clustered <chr>, co2_footprint <dbl>

# tiltIndicatorAfter drops unmatched products
 tiltIndicatorAfter::profile_emissions(
  companies,
  co2,
  europages_companies,
  ecoinvent_activities,
  ecoinvent_europages,
  isic_name
) |> 
  unnest_product() |> 
  relocate(matches("uuid"))
#> ℹ Adding NA% and NA% noise to `co2e_lower` and `co2e_upper`, respectively.
#> # A tibble: 6 × 25
#>   activity_uuid_product_uuid  companies_id company_name country emission_profile
#>   <chr>                       <chr>        <chr>        <chr>   <chr>           
#> 1 76269c17-78d6-420b-991a-aa… antimonarch… antimonarch… germany high            
#> 2 76269c17-78d6-420b-991a-aa… antimonarch… antimonarch… germany high            
#> 3 76269c17-78d6-420b-991a-aa… antimonarch… antimonarch… germany high            
#> 4 76269c17-78d6-420b-991a-aa… antimonarch… antimonarch… germany high            
#> 5 76269c17-78d6-420b-991a-aa… antimonarch… antimonarch… germany high            
#> 6 76269c17-78d6-420b-991a-aa… antimonarch… antimonarch… germany high            
#> # ℹ 20 more variables: benchmark <chr>, ep_product <chr>,
#> #   matched_activity_name <chr>, matched_reference_product <chr>,
#> #   co2e_lower <dbl>, co2e_upper <dbl>, unit <chr>, multi_match <lgl>,
#> #   matching_certainty <chr>, matching_certainty_company_average <chr>,
#> #   tilt_sector <chr>, tilt_subsector <chr>, isic_4digit <chr>,
#> #   isic_4digit_name <chr>, company_city <chr>, postcode <chr>, address <chr>,
#> #   main_activity <chr>, profile_ranking <dbl>, ei_geography <chr>
```

</details>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
