### PR TITLE
Fix formatting in one sentence of the docs

### DIFF
--- a/R/profile_emissions_upstream.R
+++ b/R/profile_emissions_upstream.R
@@ -9,9 +9,9 @@
 #'
 #' The columns `co2e_lower` and `co2e_upper` show the lowest and highest value
 #' of `co2_footprint` within the group to which the product was compared, plus
-#' some randomness. Therefore, every benchmark can have different `co2e_lower`
-#' and `co2e_upper`, because every benchmark can contain a different set of
-#' products.
+#' some randomness. Therefore, every benchmark can have different
+#' `co2e_lower` and `co2e_upper`, because every benchmark can contain a
+#' different set of products.
 #'
 #' @export
 #'

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -57,9 +57,9 @@ A data frame with the column \code{companies_id}, and the nested columns\code{pr
 
 The columns \code{co2e_lower} and \code{co2e_upper} show the lowest and highest value
 of \code{co2_footprint} within the group to which the product was compared, plus
-some randomness. Therefore, every benchmark can have different \code{co2e_lower}
-and \code{co2e_upper}, because every benchmark can contain a different set of
-products.
+some randomness. Therefore, every benchmark can have different
+\code{co2e_lower} and \code{co2e_upper}, because every benchmark can contain a
+different set of products.
 }
 \description{
 These functions wrap the output of the corresponding function in


### PR DESCRIPTION
This PR fixes the formatting of a sentence in the docs. It's a minor thing but is a small change so I'll fix it while I'm here.

The cause is unclear though. It seems that code-formatting (back ticks) right at the end of a line are confused with a line break.


https://2degreesinvesting.github.io/tiltIndicatorAfter/reference/profile_emissions_upstream.html#value

![image](https://github.com/2DegreesInvesting/tiltIndicatorAfter/assets/5856545/1bba9f86-840b-49cd-adeb-a8d0e9cd6bde)

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer. I'll go ahead and merge with no review since it's a tiny change that doesn't touch production code.
