### PR TITLE
`exclude_cols_then_pivot_wider()` gains `avoid_list_cols`

### DIFF
--- a/R/exclude_cols_then_pivot_wider.R
+++ b/R/exclude_cols_then_pivot_wider.R
@@ -46,6 +46,8 @@ exclude_cols_then_pivot_wider <- function(data,
   if (!avoid_list_cols) {
     pruned |> pivot_wider(...)
   } else {
+    check_values_fn(...)
+
     pruned |>
       pivot_wider(..., values_fn = list) |>
       tidyr::unchop(tidyselect::everything()) |>
@@ -53,3 +55,8 @@ exclude_cols_then_pivot_wider <- function(data,
   }
 }
 
+check_values_fn <- function(...) {
+  if (hasName(list(...), "values_fn")) {
+    abort("`values_fn` should not be used when `avoid_list_cols = TRUE`.")
+  }
+}

--- a/R/exclude_cols_then_pivot_wider.R
+++ b/R/exclude_cols_then_pivot_wider.R
@@ -37,6 +37,33 @@
 #' data |>
 #'   pivot_wider(id_cols = id, names_from = "name", values_from = "value") |>
 #'   unnest(c(a, b))
+#'
+#' # styler: off
+#' data <- tribble(
+#'    ~id, ~name, ~value, ~to_exclude, ~yields_duplicates,
+#'   "id",   "a",      1,           1,                  1,
+#'   "id",   "a",      1,           2,                  2
+#' )
+#' # styler: on
+#'
+#' # `data` may have columns that yield duplicates and thus list-columns
+#' with_list_cols <- exclude_cols_then_pivot_wider(
+#'   data,
+#'   exclude_cols = "to_exclude",
+#'   id_cols = "id"
+#' )
+#' # You can handle it after the fact
+#' with_list_cols |>
+#'   tidyr::unnest(everything()) |>
+#'   distinct()
+#'
+#' # But also you can avoid it with `avoid_list_cols = TRUE`
+#' exclude_cols_then_pivot_wider(
+#'   data,
+#'   exclude_cols = "to_exclude",
+#'   id_cols = "id",
+#'   avoid_list_cols = TRUE
+#' )
 exclude_cols_then_pivot_wider <- function(data,
                                           ...,
                                           exclude_cols = NULL,

--- a/R/exclude_cols_then_pivot_wider.R
+++ b/R/exclude_cols_then_pivot_wider.R
@@ -4,6 +4,8 @@
 #' @param ... Arguments passed to [tidyr::pivot_wider()].
 #' @param exclude_cols A character vector giving regular expressions matching
 #'   column names to exclude. If lengh > 1, the union is taken.
+#' @param avoid_list_cols Logical. Avoid all list-columns, duplicates, and the
+#'   associated warning?
 #'
 #' @return A data frame giving the result you get from [tidyr::pivot_wider()] if
 #'   `data` lacks the excluded columns and the resulting duplicates.

--- a/R/exclude_cols_then_pivot_wider.R
+++ b/R/exclude_cols_then_pivot_wider.R
@@ -47,7 +47,7 @@ exclude_cols_then_pivot_wider <- function(data,
     pruned |> pivot_wider(...)
   } else {
     pruned |>
-      pivot_wider(...) |>
+      pivot_wider(..., values_fn = list) |>
       tidyr::unchop(tidyselect::everything())
   }
 }

--- a/R/exclude_cols_then_pivot_wider.R
+++ b/R/exclude_cols_then_pivot_wider.R
@@ -35,9 +35,20 @@
 #' data |>
 #'   pivot_wider(id_cols = id, names_from = "name", values_from = "value") |>
 #'   unnest(c(a, b))
-exclude_cols_then_pivot_wider <- function(data, ..., exclude_cols = NULL) {
-  data |>
+exclude_cols_then_pivot_wider <- function(data,
+                                          ...,
+                                          exclude_cols = NULL,
+                                          avoid_list_cols = FALSE) {
+  pruned <- data |>
     select(-matches(exclude_cols)) |>
-    distinct() |>
-    pivot_wider(...)
+    distinct()
+
+  if (!avoid_list_cols) {
+    pruned |> pivot_wider(...)
+  } else {
+    pruned |>
+      pivot_wider(...) |>
+      tidyr::unchop(tidyselect::everything())
+  }
 }
+

--- a/R/exclude_cols_then_pivot_wider.R
+++ b/R/exclude_cols_then_pivot_wider.R
@@ -48,7 +48,8 @@ exclude_cols_then_pivot_wider <- function(data,
   } else {
     pruned |>
       pivot_wider(..., values_fn = list) |>
-      tidyr::unchop(tidyselect::everything())
+      tidyr::unchop(tidyselect::everything()) |>
+      distinct()
   }
 }
 

--- a/man/exclude_cols_then_pivot_wider.Rd
+++ b/man/exclude_cols_then_pivot_wider.Rd
@@ -54,5 +54,32 @@ data |> pivot_wider()
 data |>
   pivot_wider(id_cols = id, names_from = "name", values_from = "value") |>
   unnest(c(a, b))
+
+# styler: off
+data <- tribble(
+   ~id, ~name, ~value, ~to_exclude, ~yields_duplicates,
+  "id",   "a",      1,           1,                  1,
+  "id",   "a",      1,           2,                  2
+)
+# styler: on
+
+# `data` may have columns that yield duplicates and thus list-columns
+with_list_cols <- exclude_cols_then_pivot_wider(
+  data,
+  exclude_cols = "to_exclude",
+  id_cols = "id"
+)
+# You can handle it after the fact
+with_list_cols |>
+  tidyr::unnest(everything()) |>
+  distinct()
+
+# But also you can avoid it with `avoid_list_cols = TRUE`
+exclude_cols_then_pivot_wider(
+  data,
+  exclude_cols = "to_exclude",
+  id_cols = "id",
+  avoid_list_cols = TRUE
+)
 }
 \keyword{internal}

--- a/man/exclude_cols_then_pivot_wider.Rd
+++ b/man/exclude_cols_then_pivot_wider.Rd
@@ -4,7 +4,12 @@
 \alias{exclude_cols_then_pivot_wider}
 \title{Excluding irrelevant columns and duplicates, then pivot from long to wide}
 \usage{
-exclude_cols_then_pivot_wider(data, ..., exclude_cols = NULL)
+exclude_cols_then_pivot_wider(
+  data,
+  ...,
+  exclude_cols = NULL,
+  avoid_list_cols = FALSE
+)
 }
 \arguments{
 \item{data}{A data frame to pivot.}
@@ -13,6 +18,9 @@ exclude_cols_then_pivot_wider(data, ..., exclude_cols = NULL)
 
 \item{exclude_cols}{A character vector giving regular expressions matching
 column names to exclude. If lengh > 1, the union is taken.}
+
+\item{avoid_list_cols}{Logical. Avoid all list-columns, duplicates, and the
+associated warning?}
 }
 \value{
 A data frame giving the result you get from \code{\link[tidyr:pivot_wider]{tidyr::pivot_wider()}} if

--- a/tests/testthat/_snaps/exclude_cols_then_pivot_wider.md
+++ b/tests/testthat/_snaps/exclude_cols_then_pivot_wider.md
@@ -1,0 +1,4 @@
+# with `avoid_list_cols` AND `values_fn` errors gracefully
+
+    `values_fn` should not be used when `avoid_list_cols = TRUE`.
+

--- a/tests/testthat/test-exclude_cols_then_pivot_wider.R
+++ b/tests/testthat/test-exclude_cols_then_pivot_wider.R
@@ -20,16 +20,19 @@ test_that("can avoid list-columns, the warning, and duplicates", {
     ~to_exclude,  ~id, ~name,  ~value,
               1, "id",   "a",       1,
               2, "id",   "a",       1,
-  )
-  # styler: on
+  ) |>
+    mutate(another_col_that_yields_duplicates = to_exclude)
+    # styler: on
 
-  out <- data |>
-    mutate(another_col_that_yields_duplicates = to_exclude) |>
-    exclude_cols_then_pivot_wider(
+
+  expect_no_warning({
+    out <- exclude_cols_then_pivot_wider(
+      data,
       exclude_cols = "to_exclude",
       id_cols = "id",
       avoid_list_cols = TRUE
     )
+  })
 
   expect_type(out$a, "double")
 })

--- a/tests/testthat/test-exclude_cols_then_pivot_wider.R
+++ b/tests/testthat/test-exclude_cols_then_pivot_wider.R
@@ -13,3 +13,23 @@ test_that("excludes columns matching a pattern and leaves no duplicates", {
   expect_equal(nrow(out), 1L)
   expect_false(hasName(out, "to_exclude"))
 })
+
+test_that("can avoid list-columns, the warning, and duplicates", {
+  # styler: off
+  data <- tribble(
+    ~to_exclude,  ~id, ~name,  ~value,
+              1, "id",   "a",       1,
+              2, "id",   "a",       1,
+  )
+  # styler: on
+
+  out <- data |>
+    mutate(another_col_that_yields_duplicates = to_exclude) |>
+    exclude_cols_then_pivot_wider(
+      exclude_cols = "to_exclude",
+      id_cols = "id",
+      avoid_list_cols = TRUE
+    )
+
+  expect_type(out$a, "double")
+})

--- a/tests/testthat/test-exclude_cols_then_pivot_wider.R
+++ b/tests/testthat/test-exclude_cols_then_pivot_wider.R
@@ -35,4 +35,5 @@ test_that("can avoid list-columns, the warning, and duplicates", {
   })
 
   expect_type(out$a, "double")
+  expect_false(any(duplicated(out)))
 })

--- a/tests/testthat/test-exclude_cols_then_pivot_wider.R
+++ b/tests/testthat/test-exclude_cols_then_pivot_wider.R
@@ -37,3 +37,24 @@ test_that("can avoid list-columns, the warning, and duplicates", {
   expect_type(out$a, "double")
   expect_false(any(duplicated(out)))
 })
+
+test_that("with `avoid_list_cols` AND `values_fn` errors gracefully", {
+  # styler: off
+  data <- tribble(
+    ~to_exclude,  ~id, ~name,  ~value,
+              1, "id",   "a",       1,
+              2, "id",   "a",       1,
+  ) |>
+    mutate(another_col_that_yields_duplicates = to_exclude)
+    # styler: on
+
+  expect_snapshot_error(
+    exclude_cols_then_pivot_wider(
+      data,
+      exclude_cols = "to_exclude",
+      id_cols = "id",
+      avoid_list_cols = TRUE,
+      values_fn = list
+    )
+  )
+})


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/205#discussion_r1555755033. 
Thanks @kalashsinghal 

`exclude_cols_then_pivot_wider()` now allows avoiding list-columns via the new argument `avoid_list_cols`. 

This is a coarse, catch-all alternative to the finer grained control you get via `id_cols`. While it's generally best to specify the `id_cols` you care about, it's hard to anticipate what columns the real data might have, and some of them may introduce list-columns, duplicates, and trigger a warning. This new argument avoids all of that.

<details/>
<summary/>
reprex
</summary>

``` r
devtools::load_all()
#> ℹ Loading tiltIndicatorAfter

library(dplyr, warn.conflicts = FALSE)
library(tidyr, warn.conflicts = FALSE)

# styler: off
data <- tribble(
  ~id, ~name, ~value, ~to_exclude, ~yields_duplicates,
  "id",   "a",      1,           1,                  1,
  "id",   "a",      1,           2,                  2
)
# styler: on

# `data` may have columns that yield duplicates and thus list-columns
with_list_cols <- exclude_cols_then_pivot_wider(
  data,
  exclude_cols = "to_exclude",
  id_cols = "id"
)
#> Warning: Values from `value` are not uniquely identified; output will contain list-cols.
#> • Use `values_fn = list` to suppress this warning.
#> • Use `values_fn = {summary_fun}` to summarise duplicates.
#> • Use the following dplyr code to identify duplicates.
#>   {data} |>
#>   dplyr::summarise(n = dplyr::n(), .by = c(id, name)) |>
#>   dplyr::filter(n > 1L)
with_list_cols
#> # A tibble: 1 × 2
#>   id    a        
#>   <chr> <list>   
#> 1 id    <dbl [2]>

# You can handle it after the fact
with_list_cols |> unnest(everything()) |> distinct()
#> # A tibble: 1 × 2
#>   id        a
#>   <chr> <dbl>
#> 1 id        1

# But also you can avoid it with `avoid_list_cols = TRUE`
exclude_cols_then_pivot_wider(
  data,
  exclude_cols = "to_exclude",
  id_cols = "id",
  avoid_list_cols = TRUE
)
#> # A tibble: 1 × 2
#>   id        a
#>   <chr> <dbl>
#> 1 id        1
```

</details>



----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
