### PR TITLE
`inform_percent_noise()` now yields correct noise, not "NA% and NA%"

### DIFF
--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -25,8 +25,8 @@ inform_mean_percent_noise <- function(data) {
     return(data)
   }
 
-  l <- round(mean(percent_noise(data$min, data$min_jitter)))
-  u <- round(mean(percent_noise(data$max, data$max_jitter)))
+  l <- round(mean(percent_noise(data$min, data$min_jitter), na.rm = TRUE))
+  u <- round(mean(percent_noise(data$max, data$max_jitter), na.rm = TRUE))
   rlang::inform(c(i = glue(
     "Adding {l}% and {u}% noise to `co2e_lower` and `co2e_upper`, respectively."
   )))

--- a/tests/testthat/_snaps/profile_emissions.md
+++ b/tests/testthat/_snaps/profile_emissions.md
@@ -38,3 +38,17 @@
     Message
       i Adding 48% and 99% noise to `co2e_lower` and `co2e_upper`, respectively.
 
+# informs a useful percent noise (not 'Adding NA% ... noise') (#188)
+
+    Code
+      profile_emissions(companies, products, europages_companies = europages_companies,
+        ecoinvent_activities = ecoinvent_activities, ecoinvent_europages = ecoinvent_europages,
+        isic = isic_name)
+    Message
+      i Adding 43% and 99% noise to `co2e_lower` and `co2e_upper`, respectively.
+    Output
+      # A tibble: 1 x 3
+        companies_id        product           company           
+        <chr>               <list>            <list>            
+      1 antimonarchy_canine <tibble [7 x 24]> <tibble [24 x 13]>
+

--- a/tests/testthat/test-profile_emissions.R
+++ b/tests/testthat/test-profile_emissions.R
@@ -592,3 +592,32 @@ test_that("yield NA in `*tilt_sector` and `*tilt_subsector` in *profile$ risk co
   these_cols_are_full_of_na <- all(is.na(select(na, tilt_sector, tilt_subsector)))
   expect_true(these_cols_are_full_of_na)
 })
+
+test_that("informs a useful percent noise (not 'Adding NA% ... noise') (#188)", {
+  withr::local_options(tiltIndicatorAfter.verbose = TRUE)
+
+  companies <- read_csv(toy_emissions_profile_any_companies(), n_max = 1)
+  companies <- bind_rows(companies, companies)
+  companies$activity_uuid_product_uuid[[1]] <- "unmatched"
+  uuid <- unique(companies$activity_uuid_product_uuid)
+  products <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
+    filter(activity_uuid_product_uuid %in% uuid)
+
+  europages_companies <- read_csv(toy_europages_companies())
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  isic_name <- read_csv(toy_isic_name())
+
+  withr::local_seed(1)
+  # Before this fix the message was "NA% and NA%"
+  expect_snapshot(
+    profile_emissions(
+      companies,
+      products,
+      europages_companies = europages_companies,
+      ecoinvent_activities = ecoinvent_activities,
+      ecoinvent_europages = ecoinvent_europages,
+      isic = isic_name
+    )
+  )
+})


### PR DESCRIPTION
Closes #188 

This PR removes `NA`s when `inform_percent_noise()` computes the mean noise. The reprex shows that the message matches the calculated values:

<details/>
<summary/>
reprex
</summary>

``` r
devtools::load_all()
#> ℹ Loading tiltIndicatorAfter

library(dplyr, warn.conflicts = FALSE)
library(readr, warn.conflicts = FALSE)

withr::local_options(readr.show_col_types = FALSE)
withr::local_options(tiltIndicatorAfter.output_co2_footprint_min_max = TRUE)
withr::local_options(tiltIndicatorAfter.output_co2_footprint = TRUE)
withr::local_seed(1)

companies <- read_csv(toy_emissions_profile_any_companies(), n_max = 1)
companies <- bind_rows(companies, companies)
companies$activity_uuid_product_uuid[[1]] <- "unmatched"
uuid <- unique(companies$activity_uuid_product_uuid)
products <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
  filter(activity_uuid_product_uuid %in% uuid)

europages_companies <- read_csv(toy_europages_companies())
ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
isic_name <- read_csv(toy_isic_name())

out <- profile_emissions(
  companies,
  products,
  europages_companies = europages_companies,
  ecoinvent_activities = ecoinvent_activities,
  ecoinvent_europages = ecoinvent_europages,
  isic = isic_name
) |> unnest_product() |> 
  select(matches(c("min", "max", "co2")))
#> ℹ Adding 43% and 99% noise to `co2e_lower` and `co2e_upper`, respectively.

percent_noise(out$min, out$co2e_lower) |> mean(na.rm = TRUE) |> round()
#> [1] 43
percent_noise(out$max, out$co2e_upper) |> mean(na.rm = TRUE) |> round()
#> [1] 99
```

</details>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
