### PR TITLE
Refactor: Rename internal `option_*()` helpers

### DIFF
--- a/R/tiltIndicatorAfter-options.R
+++ b/R/tiltIndicatorAfter-options.R
@@ -58,18 +58,18 @@
 #'   select(matches(c("min", "max", "co2")))
 NULL
 
-set_jitter_amount <- function() {
+option_jitter_amount <- function() {
   getOption("tiltIndicatorAfter.set_jitter_amount", default = 2)
 }
 
-output_co2_footprint_min_max <- function() {
+option_output_min_max <- function() {
   getOption("tiltIndicatorAfter.output_co2_footprint_min_max", default = FALSE)
 }
 
-output_co2_footprint <- function() {
+option_output_co2_footprint <- function() {
   getOption("tiltIndicatorAfter.output_co2_footprint", default = FALSE)
 }
 
-verbose <- function() {
+option_verbose <- function() {
   getOption("tiltIndicatorAfter.verbose", default = TRUE)
 }

--- a/R/utils-co2.R
+++ b/R/utils-co2.R
@@ -1,4 +1,4 @@
-create_co2_range <- function(data, amount = set_jitter_amount()) {
+create_co2_range <- function(data, amount = option_jitter_amount()) {
   col <- extract_name(data, "co2_footprint")
   .by <- c("grouped_by", "risk_category")
 
@@ -10,7 +10,7 @@ create_co2_range <- function(data, amount = set_jitter_amount()) {
 
   out <- out |> rename(co2e_lower = "min_jitter", co2e_upper = "max_jitter")
 
-  if (output_co2_footprint_min_max()) {
+  if (option_output_min_max()) {
     return(out)
   }
 
@@ -22,7 +22,7 @@ add_co2_upper_lower <- function(data, co2_range) {
 }
 
 inform_mean_percent_noise <- function(data) {
-  if (!verbose()) {
+  if (!option_verbose()) {
     return(data)
   }
 
@@ -36,7 +36,7 @@ inform_mean_percent_noise <- function(data) {
 }
 
 optionally_output_co2_footprint <- function(out, co2_footprint) {
-  if (!output_co2_footprint()) {
+  if (!option_output_co2_footprint()) {
     return(out)
   }
 


### PR DESCRIPTION
This PR is refactoring only. It gives more evocative and consistent names 
to the functions that get options.

These changes moved from #214, in order to reduce the diff of that PR.



----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
