### PR TITLE
Record percent noise in new columns

### DIFF
--- a/R/add_co2-add_noise_in_co2_range.R
+++ b/R/add_co2-add_noise_in_co2_range.R
@@ -1,0 +1,8 @@
+add_noise_in_co2_range <- function(data) {
+  round_mean <- function(x, y) round(mean(percent_noise(x, y), na.rm = TRUE))
+  data |>
+    mutate(
+      min_noise_percent = round_mean(.data$min, .data$min_jitter), na.rm = TRUE,
+      max_noise_percent = round_mean(.data$max, .data$max_jitter), na.rm = TRUE
+    )
+}

--- a/R/add_co2-inform_noise_in_co2_range.R
+++ b/R/add_co2-inform_noise_in_co2_range.R
@@ -1,0 +1,13 @@
+inform_noise_in_co2_range <- function(data) {
+  if (!option_verbose()) {
+    return(invisible(data))
+  }
+
+  l <- round(mean(percent_noise(data$min, data$min_jitter), na.rm = TRUE))
+  u <- round(mean(percent_noise(data$max, data$max_jitter), na.rm = TRUE))
+  inform(c(i = glue(
+    "Adding {l}% and {u}% noise to `{col_min_jitter()}` and `{col_max_jitter()}`, respectively."
+  )))
+
+  invisible(data)
+}

--- a/tests/testthat/test-add_co2-inform_noise_in_co2_range.R
+++ b/tests/testthat/test-add_co2-inform_noise_in_co2_range.R
@@ -1,0 +1,29 @@
+test_that("informs the expected amount of noise", {
+  withr::local_options(tiltIndicatorAfter.verbose = TRUE)
+
+  min <- 1:3
+  max <- 4:6
+  # Add 10% noise
+  min_jitter <- -min * 1.1
+  # Add 50% noise
+  max_jitter <- max * 1.5
+  data <- tibble(min_jitter, min, max, max_jitter)
+
+  expect_message(inform_noise_in_co2_range(data), "10%.*50%")
+})
+
+test_that("if verbose, returns invisibly", {
+  withr::local_options(tiltIndicatorAfter.verbose = TRUE)
+  data <- tibble(min_jitter = 1, min = 2, max = 3, max_jitter = 4)
+  suppressMessages(
+    expect_invisible(inform_noise_in_co2_range(data))
+  )
+})
+
+test_that("if not verbose, returns invisibly", {
+  withr::local_options(tiltIndicatorAfter.verbose = FALSE)
+  data <- tibble(min_jitter = 1, min = 2, max = 3, max_jitter = 4)
+  suppressMessages(
+    expect_invisible(inform_noise_in_co2_range(data))
+  )
+})


### PR DESCRIPTION
* Relates to #214 

Extends the 'add_co2' module to add noise as columns, rathen than a warning/message. This makes it easier to work with, both for analysts and developers.

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
