### PR TITLE
Refactor `best_case_worst_case_emission_profile` function 

### DIFF
--- a/R/best_case_worst_case_emission_profile.R
+++ b/R/best_case_worst_case_emission_profile.R
@@ -11,83 +11,14 @@
 #'
 #' product |> best_case_worst_case_emission_profile()
 best_case_worst_case_emission_profile <- function(data) {
-  check_crucial_cols(data)
-
-  data |>
-    mutate(
-      n_distinct_products = n_distinct(.data[[col_europages_product()]], na.rm = TRUE),
-      .by = col_companies_id()
-    ) |>
-    mutate(
-      equal_weight = ifelse(.data$n_distinct_products == 0, NA,
-        1 / .data$n_distinct_products
-      )
-    ) |>
-    mutate(
-      min_risk_category_per_company_benchmark = risk_first_occurance(
-        .data,
-        risk_order = c("low", "medium", "high")
-      ),
-      .by = c(col_companies_id(), col_grouped_by())
-    ) |>
-    mutate(
-      max_risk_category_per_company_benchmark = risk_first_occurance(
-        .data,
-        risk_order = c("high", "medium", "low")
-      ),
-      .by = c(col_companies_id(), col_grouped_by())
-    ) |>
-    mutate(
-      best_risk = get_risk_match_if_emission_profile_has_no_na(
-        .data, col_emission_profile(),
-        "min_risk_category_per_company_benchmark"
-      )
-    ) |>
-    mutate(
-      worst_risk = get_risk_match_if_emission_profile_has_no_na(
-        .data, col_emission_profile(),
-        "max_risk_category_per_company_benchmark"
-      )
-    ) |>
-    mutate(
-      count_best_case_products_per_company_benchmark = sum(.data$best_risk),
-      .by = c(col_companies_id(), col_grouped_by())
-    ) |>
-    mutate(
-      count_worst_case_products_per_company_benchmark = sum(.data$worst_risk),
-      .by = c(col_companies_id(), col_grouped_by())
-    ) |>
-    mutate(
-      best_case = get_case_if_risk_counts_has_no_zero(
-        .data, "best_risk",
-        "count_best_case_products_per_company_benchmark"
-      )
-    ) |>
-    mutate(
-      worst_case = get_case_if_risk_counts_has_no_zero(
-        .data, "worst_risk",
-        "count_worst_case_products_per_company_benchmark"
-      )
-    )
-}
-
-risk_first_occurance <- function(data, risk_order) {
-  risk_order[which(risk_order %in% data[[col_emission_profile()]])[1]]
-}
-
-get_risk_match_if_emission_profile_has_no_na <- function(data, emission_profile, risk_category_per_company_benchmark) {
-  ifelse(is.na(data[[emission_profile]]), 0,
-    ifelse(data[[emission_profile]] == data[[risk_category_per_company_benchmark]], 1, 0)
+  crucial_cols <- c(
+    col_companies_id(), col_europages_product(),
+    col_emission_grouped_by(), col_emission_profile()
   )
-}
+  check_crucial_cols(data, crucial_cols)
 
-get_case_if_risk_counts_has_no_zero <- function(data, risk, count_risk_cases_per_company_benchmark) {
-  ifelse(data[[count_risk_cases_per_company_benchmark]] == 0, NA,
-    data[[risk]] / data[[count_risk_cases_per_company_benchmark]]
+  best_case_worst_case_impl(data,
+    col_risk = col_emission_profile(),
+    col_group_by = col_emission_grouped_by()
   )
-}
-
-check_crucial_cols <- function(data) {
-  crucial_cols <- c(col_companies_id(), col_europages_product(), col_grouped_by(), col_emission_profile())
-  walk(crucial_cols, ~ check_matches_name(data, .x))
 }

--- a/R/best_case_worst_case_impl.R
+++ b/R/best_case_worst_case_impl.R
@@ -1,0 +1,13 @@
+best_case_worst_case_impl <- function(data, col_risk, col_group_by) {
+  data |>
+    compute_n_distinct_products() |>
+    compute_equal_weight() |>
+    compute_min_risk_category_per_company_benchmark(col_risk, col_group_by) |>
+    compute_max_risk_category_per_company_benchmark(col_risk, col_group_by) |>
+    compute_best_risk(col_risk) |>
+    compute_worst_risk(col_risk) |>
+    compute_count_best_case_products_per_company_benchmark(col_group_by) |>
+    compute_count_worst_case_products_per_company_benchmark(col_group_by) |>
+    compute_best_case() |>
+    compute_worst_case()
+}

--- a/R/cols-best_case_worst_case.R
+++ b/R/cols-best_case_worst_case.R
@@ -6,7 +6,7 @@ col_europages_product <- function() {
   "ep_product"
 }
 
-col_grouped_by <- function() {
+col_emission_grouped_by <- function() {
   "benchmark"
 }
 

--- a/R/utils-best_case_worst_case.R
+++ b/R/utils-best_case_worst_case.R
@@ -1,0 +1,106 @@
+risk_first_occurance <- function(data, col_risk, risk_order) {
+  risk_order[which(risk_order %in% data[[col_risk]])[1]]
+}
+
+get_risk_match_if_emission_profile_has_no_na <- function(data, col_risk, risk_category_per_company_benchmark) {
+  ifelse(is.na(data[[col_risk]]), 0,
+    ifelse(data[[col_risk]] == data[[risk_category_per_company_benchmark]], 1, 0)
+  )
+}
+
+get_case_if_risk_counts_has_no_zero <- function(data, risk, count_risk_cases_per_company_benchmark) {
+  ifelse(data[[count_risk_cases_per_company_benchmark]] == 0, NA,
+    data[[risk]] / data[[count_risk_cases_per_company_benchmark]]
+  )
+}
+
+compute_n_distinct_products <- function(data) {
+  mutate(data,
+    n_distinct_products = n_distinct(.data[[col_europages_product()]], na.rm = TRUE),
+    .by = col_companies_id()
+  )
+}
+
+compute_equal_weight <- function(data) {
+  mutate(data,
+    equal_weight = ifelse(.data$n_distinct_products == 0, NA,
+      1 / .data$n_distinct_products
+    )
+  )
+}
+
+compute_min_risk_category_per_company_benchmark <- function(data, col_risk, col_group_by) {
+  mutate(data,
+    min_risk_category_per_company_benchmark = risk_first_occurance(
+      .data,
+      col_risk = col_risk,
+      risk_order = c("low", "medium", "high")
+    ),
+    .by = c(col_companies_id(), col_group_by)
+  )
+}
+
+compute_max_risk_category_per_company_benchmark <- function(data, col_risk, col_group_by) {
+  mutate(data,
+    max_risk_category_per_company_benchmark = risk_first_occurance(
+      .data,
+      col_risk = col_risk,
+      risk_order = c("high", "medium", "low")
+    ),
+    .by = c(col_companies_id(), col_group_by)
+  )
+}
+
+compute_best_risk <- function(data, col_risk) {
+  mutate(data,
+    best_risk = get_risk_match_if_emission_profile_has_no_na(
+      .data, col_risk,
+      "min_risk_category_per_company_benchmark"
+    )
+  )
+}
+
+compute_worst_risk <- function(data, col_risk) {
+  mutate(data,
+    worst_risk = get_risk_match_if_emission_profile_has_no_na(
+      .data, col_risk,
+      "max_risk_category_per_company_benchmark"
+    )
+  )
+}
+
+compute_count_best_case_products_per_company_benchmark <- function(data, col_group_by) {
+  mutate(data,
+    count_best_case_products_per_company_benchmark = sum(.data$best_risk),
+    .by = c(col_companies_id(), col_group_by)
+  )
+}
+
+compute_count_worst_case_products_per_company_benchmark <- function(data, col_group_by) {
+  mutate(data,
+    count_worst_case_products_per_company_benchmark = sum(.data$worst_risk),
+    .by = c(col_companies_id(), col_group_by)
+  )
+}
+
+compute_best_case <- function(data) {
+  mutate(data,
+    best_case = get_case_if_risk_counts_has_no_zero(
+      .data, "best_risk",
+      "count_best_case_products_per_company_benchmark"
+    )
+  )
+}
+
+compute_worst_case <- function(data) {
+  mutate(data,
+    worst_case = get_case_if_risk_counts_has_no_zero(
+      .data, "worst_risk",
+      "count_worst_case_products_per_company_benchmark"
+    )
+  )
+}
+
+check_crucial_cols <- function(data, crucial_cols) {
+  walk(crucial_cols, ~ check_matches_name(data, .x))
+}

--- a/man/transition_risk_profile.Rd
+++ b/man/transition_risk_profile.Rd
@@ -78,7 +78,8 @@ toy_sector_profile <- profile_sector(
   isic = toy_isic_name
 )
 
-output <- transition_risk_profile(emissions_profile = toy_emissions_profile,
+output <- transition_risk_profile(
+  emissions_profile = toy_emissions_profile,
   sector_profile = toy_sector_profile,
   co2 = toy_emissions_profile_products_ecoinvent,
   all_activities_scenario_sectors = toy_all_activities_scenario_sectors,

--- a/tests/testthat/test-best_case_worst_case_emission_profile.R
+++ b/tests/testthat/test-best_case_worst_case_emission_profile.R
@@ -55,7 +55,7 @@ test_that("if `emission_profile_at_product_level` lacks crucial columns, errors 
   bad <- select(example_data, -all_of(crucial))
   expect_error(best_case_worst_case_emission_profile(bad), crucial)
 
-  crucial <- col_grouped_by()
+  crucial <- col_emission_grouped_by()
   bad <- select(example_data, -all_of(crucial))
   expect_error(best_case_worst_case_emission_profile(bad), crucial)
 


### PR DESCRIPTION
Relates to #248 

Dear @maurolepore 

As we now want to implement `best case and worst case` methodology to transition risk indicator, we need to refactor the current code so that the duplication can be removed and we can use the existing code to calculate the best case and worst case for other indicators. 

Please review the refactoring! Thanks!

cc @Tilmon 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [x] Document user-facing changes in the changelog.
