### PR TITLE
Remove unnecessary best case and worst case columns for `transition risk profile`

### DIFF
--- a/R/best_case_worst_case.R
+++ b/R/best_case_worst_case.R
@@ -2,7 +2,7 @@ best_case_worst_case <- function(data) {
   product <- data |>
     unnest_product() |>
     best_case_worst_case_emission_profile() |>
-    polish_best_case_worst_case_emission_profile()
+    polish_best_case_worst_case()
 
   company <- data |>
     unnest_company()

--- a/R/polish_best_case_worst_case.R
+++ b/R/polish_best_case_worst_case.R
@@ -1,4 +1,4 @@
-polish_best_case_worst_case_emission_profile <- function(data) {
+polish_best_case_worst_case <- function(data) {
   data |>
     select(-c(
       "min_risk_category_per_company_benchmark",

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -98,6 +98,7 @@ transition_risk_profile <- function(emissions_profile,
     )) |>
     add_transition_risk_category() |>
     best_case_worst_case_transition_risk_profile() |>
+    polish_best_case_worst_case() |>
     polish_transition_risk_at_product_level()
 
   company <- transition_risk_scores |>


### PR DESCRIPTION
Relates to #248 

This PR removes unnecessary best case and worst case columns for `transition risk profile`

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR description to reflect what it ended up doing.
- [ ] Polish the PR title as you'd like others to read it from the git log.
- [ ] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
