### PR TITLE
Add `best_case_worst_case_transition_risk_profile_at_company_level` function to create columns `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`

### DIFF
--- a/R/best_case_worst_case_transition_risk_profile_at_company_level.R
+++ b/R/best_case_worst_case_transition_risk_profile_at_company_level.R
@@ -68,9 +68,9 @@ add_avg_transition_risk <- function(data) {
 add_avg_transition_risk_best_case <- function(data) {
   mutate(data,
     avg_transition_risk_best_case =
-      ifelse(.data$transition_risk_category ==
-        .data$min_risk_category_per_company_benchmark,
-        .data$avg_transition_risk, NA_real_
+      assign_avg_transition_risk_if_risk_category_match(
+        .data,
+        "min_risk_category_per_company_benchmark"
       )
   )
 }
@@ -78,10 +78,17 @@ add_avg_transition_risk_best_case <- function(data) {
 add_avg_transition_risk_worst_case <- function(data) {
   mutate(data,
     avg_transition_risk_worst_case =
-      ifelse(.data$transition_risk_category ==
-        .data$max_risk_category_per_company_benchmark,
-        .data$avg_transition_risk, NA_real_
+      assign_avg_transition_risk_if_risk_category_match(
+        .data,
+        "max_risk_category_per_company_benchmark"
       )
+  )
+}
+
+assign_avg_transition_risk_if_risk_category_match <- function(data, min_max_risk_category) {
+  ifelse(data$transition_risk_category == data[[min_max_risk_category]],
+    data$avg_transition_risk,
+    NA_real_
   )
 }
 

--- a/R/best_case_worst_case_transition_risk_profile_at_company_level.R
+++ b/R/best_case_worst_case_transition_risk_profile_at_company_level.R
@@ -54,7 +54,7 @@ create_avg_best_case_worst_case_at_product_level <- function(data) {
 add_avg_transition_risk <- function(data) {
   mutate(data,
     avg_transition_risk = ifelse(is.na(.data$transition_risk_score),
-      NA,
+      NA_real_,
       mean(.data$transition_risk_score, na.rm = TRUE)
     ),
     .by = c(
@@ -70,7 +70,7 @@ add_avg_transition_risk_best_case <- function(data) {
     avg_transition_risk_best_case =
       ifelse(.data$transition_risk_category ==
         .data$min_risk_category_per_company_benchmark,
-        .data$avg_transition_risk, NA
+        .data$avg_transition_risk, NA_real_
       )
   )
 }
@@ -80,7 +80,7 @@ add_avg_transition_risk_worst_case <- function(data) {
     avg_transition_risk_worst_case =
       ifelse(.data$transition_risk_category ==
         .data$max_risk_category_per_company_benchmark,
-        .data$avg_transition_risk, NA
+        .data$avg_transition_risk, NA_real_
       )
   )
 }

--- a/R/best_case_worst_case_transition_risk_profile_at_company_level.R
+++ b/R/best_case_worst_case_transition_risk_profile_at_company_level.R
@@ -78,8 +78,10 @@ sum_transition_risk_categories <- function(data, risk_order) {
 prepare_for_join_at_company_level <- function(data) {
   data |>
     select(-c(
-      col_transition_risk_category(), col_europages_product(),
-      "amount_of_distinct_products", "n_min_risk_category_per_company_benchmark",
+      col_transition_risk_category(),
+      col_europages_product(),
+      "amount_of_distinct_products",
+      "n_min_risk_category_per_company_benchmark",
       "n_max_risk_category_per_company_benchmark"
     )) |>
     distinct()

--- a/R/best_case_worst_case_transition_risk_profile_at_company_level.R
+++ b/R/best_case_worst_case_transition_risk_profile_at_company_level.R
@@ -1,0 +1,88 @@
+best_case_worst_case_transition_risk_profile_at_company_level <- function(data) {
+  product <- data |>
+    unnest_product()
+
+  avg_best_case_worst_case_at_product_level <- product |>
+    create_avg_best_case_worst_case_at_product_level() |>
+    prepare_for_join_at_company_level()
+
+  company <- data |>
+    unnest_company() |>
+    left_join(avg_best_case_worst_case_at_product_level, by = c(col_companies_id(),
+      "benchmark_tr_score_avg" = col_transition_risk_grouped_by()
+    )) |>
+    polish_best_case_worst_case_transition_risk_at_company_level()
+
+  tilt_profile(nest_levels(product, company))
+}
+
+create_avg_best_case_worst_case_at_product_level <- function(data) {
+  crucial_cols <- c(
+    col_companies_id(), col_europages_product(),
+    col_transition_risk_grouped_by(), col_transition_risk_category(),
+    "amount_of_distinct_products"
+  )
+  check_crucial_cols(data, crucial_cols)
+
+  data |>
+    select(crucial_cols) |>
+    count_min_risk_category_per_company_benchmark() |>
+    count_max_risk_category_per_company_benchmark() |>
+    add_avg_transition_risk_best_case() |>
+    add_avg_transition_risk_worst_case()
+}
+
+count_min_risk_category_per_company_benchmark <- function(data) {
+  mutate(data,
+    n_min_risk_category_per_company_benchmark =
+      sum_transition_risk_categories(.data, c("low", "medium", "high")),
+    .by = c(col_companies_id(), col_transition_risk_grouped_by())
+  )
+}
+
+count_max_risk_category_per_company_benchmark <- function(data) {
+  mutate(data,
+    n_max_risk_category_per_company_benchmark =
+      sum_transition_risk_categories(.data, c("high", "medium", "low")),
+    .by = c(col_companies_id(), col_transition_risk_grouped_by())
+  )
+}
+
+add_avg_transition_risk_best_case <- function(data) {
+  mutate(data,
+    avg_transition_risk_best_case =
+      (.data$n_min_risk_category_per_company_benchmark /
+        .data$amount_of_distinct_products)
+  )
+}
+
+add_avg_transition_risk_worst_case <- function(data) {
+  mutate(data,
+    avg_transition_risk_worst_case =
+      (.data$n_max_risk_category_per_company_benchmark /
+        .data$amount_of_distinct_products)
+  )
+}
+
+sum_transition_risk_categories <- function(data, risk_order) {
+  sum(data$transition_risk_category ==
+    risk_first_occurance(
+      data,
+      col_transition_risk_category(),
+      risk_order
+    ), na.rm = TRUE)
+}
+
+prepare_for_join_at_company_level <- function(data) {
+  data |>
+    select(-c(
+      col_transition_risk_category(), col_europages_product(),
+      "amount_of_distinct_products", "n_min_risk_category_per_company_benchmark",
+      "n_max_risk_category_per_company_benchmark"
+    )) |>
+    distinct()
+}
+
+polish_best_case_worst_case_transition_risk_at_company_level <- function(data) {
+  rename(data, avg_transition_risk_equal_weight = "transition_risk_score_avg")
+}

--- a/R/best_case_worst_case_transition_risk_profile_at_company_level.R
+++ b/R/best_case_worst_case_transition_risk_profile_at_company_level.R
@@ -18,8 +18,10 @@ best_case_worst_case_transition_risk_profile_at_company_level <- function(data) 
 
 create_avg_best_case_worst_case_at_product_level <- function(data) {
   crucial_cols <- c(
-    col_companies_id(), col_europages_product(),
-    col_transition_risk_grouped_by(), col_transition_risk_category(),
+    col_companies_id(),
+    col_europages_product(),
+    col_transition_risk_grouped_by(),
+    col_transition_risk_category(),
     "amount_of_distinct_products"
   )
   check_crucial_cols(data, crucial_cols)

--- a/R/example_data.R
+++ b/R/example_data.R
@@ -23,10 +23,10 @@ example_best_case_worst_case_transition_risk_profile <- example_data_factory(
 example_best_case_worst_case_transition_risk_profile_product_level <- example_data_factory(
   # styler: off
   tribble(
-    ~companies_id, ~ep_product, ~benchmark_tr_score, ~transition_risk_category, ~amount_of_distinct_products,
-            "any",       "one",               "all",                     "low",                          3.0,
-            "any",       "two",               "all",                  "medium",                          3.0,
-            "any",     "three",               "all",                    "high",                          3.0,
+    ~companies_id, ~ep_product, ~benchmark_tr_score, ~transition_risk_category, ~transition_risk_score,
+            "any",       "one",               "all",                     "low",                    1.0,
+            "any",       "two",               "all",                  "medium",                    2.0,
+            "any",     "three",               "all",                    "high",                    3.0,
   )
   # styler: on
 )

--- a/R/example_data.R
+++ b/R/example_data.R
@@ -19,3 +19,14 @@ example_best_case_worst_case_transition_risk_profile <- example_data_factory(
   )
   # styler: on
 )
+
+example_best_case_worst_case_transition_risk_profile_product_level <- example_data_factory(
+  # styler: off
+  tribble(
+    ~companies_id, ~ep_product, ~benchmark_tr_score, ~transition_risk_category, ~amount_of_distinct_products,
+            "any",       "one",               "all",                     "low",                          3.0,
+            "any",       "two",               "all",                  "medium",                          3.0,
+            "any",     "three",               "all",                    "high",                          3.0,
+  )
+  # styler: on
+)

--- a/R/score_transition_risk.R
+++ b/R/score_transition_risk.R
@@ -72,7 +72,8 @@ score_transition_risk <-
       select(-c("scenario_year", "benchmark")) |>
       left_join(
         union_emissions_sector_rows,
-        by = c("companies_id", "ep_product", "activity_uuid_product_uuid")
+        by = c("companies_id", "ep_product", "activity_uuid_product_uuid"),
+        relationship = "many-to-many"
       ) |>
       relocate(
         relocate_trs_columns(product_level_trs_column()),

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -87,7 +87,8 @@ transition_risk_profile <- function(emissions_profile,
     scenarios,
     pivot_wider = FALSE
   ) |>
-    add_transition_risk_category_at_company_level()
+    add_transition_risk_category_at_company_level() |>
+    best_case_worst_case_transition_risk_profile_at_company_level()
 }
 
 transition_risk_profile_impl <- function(emissions_profile,

--- a/R/utils-best_case_worst_case.R
+++ b/R/utils-best_case_worst_case.R
@@ -36,7 +36,7 @@ compute_min_risk_category_per_company_benchmark <- function(data, col_risk, col_
       col_risk = col_risk,
       risk_order = c("low", "medium", "high")
     ),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 
@@ -47,7 +47,7 @@ compute_max_risk_category_per_company_benchmark <- function(data, col_risk, col_
       col_risk = col_risk,
       risk_order = c("high", "medium", "low")
     ),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 
@@ -72,14 +72,14 @@ compute_worst_risk <- function(data, col_risk) {
 compute_count_best_case_products_per_company_benchmark <- function(data, col_group_by) {
   mutate(data,
     count_best_case_products_per_company_benchmark = sum(.data$best_risk),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 
 compute_count_worst_case_products_per_company_benchmark <- function(data, col_group_by) {
   mutate(data,
     count_worst_case_products_per_company_benchmark = sum(.data$worst_risk),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 

--- a/tests/testthat/_snaps/profile_emissions.md
+++ b/tests/testthat/_snaps/profile_emissions.md
@@ -14,10 +14,10 @@
       [17] "company_city"                       "postcode"                          
       [19] "address"                            "main_activity"                     
       [21] "activity_uuid_product_uuid"         "profile_ranking"                   
-      [23] "ei_geography"                       "co2_footprint"                     
-      [25] "co2e_lower"                         "co2e_upper"                        
-      [27] "amount_of_distinct_products"        "equal_weight"                      
-      [29] "best_case"                          "worst_case"                        
+      [23] "ei_geography"                       "co2e_lower"                        
+      [25] "co2e_upper"                         "amount_of_distinct_products"       
+      [27] "equal_weight"                       "best_case"                         
+      [29] "worst_case"                        
 
 ---
 

--- a/tests/testthat/_snaps/profile_emissions.md
+++ b/tests/testthat/_snaps/profile_emissions.md
@@ -14,10 +14,10 @@
       [17] "company_city"                       "postcode"                          
       [19] "address"                            "main_activity"                     
       [21] "activity_uuid_product_uuid"         "profile_ranking"                   
-      [23] "ei_geography"                       "co2e_lower"                        
-      [25] "co2e_upper"                         "amount_of_distinct_products"       
-      [27] "equal_weight"                       "best_case"                         
-      [29] "worst_case"                        
+      [23] "ei_geography"                       "co2_footprint"                     
+      [25] "co2e_lower"                         "co2e_upper"                        
+      [27] "amount_of_distinct_products"        "equal_weight"                      
+      [29] "best_case"                          "worst_case"                        
 
 ---
 

--- a/tests/testthat/test-create_avg_best_case_worst_case_at_product_level.R
+++ b/tests/testthat/test-create_avg_best_case_worst_case_at_product_level.R
@@ -1,25 +1,27 @@
-test_that("single `NA` in `transition_risk_category` gives correct values for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
+test_that("`NA` in `transition_risk_category` and `transition_risk_score` gives correct values for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
   example_data <- example_best_case_worst_case_transition_risk_profile_product_level(
-    transition_risk_category = c("low", "low", NA_character_)
+    transition_risk_category = c("low", "low", NA_character_),
+    transition_risk_score = c(1.0, 2.0, NA)
   )
 
   out <- create_avg_best_case_worst_case_at_product_level(example_data)
 
-  expected_best_case <- 2 / 3
-  expected_worst_case <- 2 / 3
+  expected_best_case <- c(3 / 2, NA)
+  expected_worst_case <- c(3 / 2, NA)
   expect_equal(unique(out$avg_transition_risk_best_case), expected_best_case)
   expect_equal(unique(out$avg_transition_risk_worst_case), expected_worst_case)
 })
 
-test_that("only `NA` in `transition_risk_category` gives `0` value for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
+test_that("only `NA` in `transition_risk_category` and `transition_risk_score` gives `NA` value for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
   example_data <- example_best_case_worst_case_transition_risk_profile_product_level(
-    transition_risk_category = NA_character_
+    transition_risk_category = NA_character_,
+    transition_risk_score = NA_character_
   )
 
   out <- create_avg_best_case_worst_case_at_product_level(example_data)
 
-  expected_best_case <- 0
-  expected_worst_case <- 0
+  expected_best_case <- NA
+  expected_worst_case <- NA
   expect_equal(unique(out$avg_transition_risk_best_case), expected_best_case)
   expect_equal(unique(out$avg_transition_risk_worst_case), expected_worst_case)
 })
@@ -44,7 +46,7 @@ test_that("if `transition_profile_at_product_level` lacks crucial columns, error
   bad <- select(example_data, -all_of(crucial))
   expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
 
-  crucial <- "amount_of_distinct_products"
+  crucial <- "transition_risk_score"
   bad <- select(example_data, -all_of(crucial))
   expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
 })

--- a/tests/testthat/test-create_avg_best_case_worst_case_at_product_level.R
+++ b/tests/testthat/test-create_avg_best_case_worst_case_at_product_level.R
@@ -5,15 +5,15 @@ test_that("single `NA` in `transition_risk_category` gives correct values for `a
 
   out <- create_avg_best_case_worst_case_at_product_level(example_data)
 
-  expected_best_case <- 2/3
-  expected_worst_case <- 2/3
+  expected_best_case <- 2 / 3
+  expected_worst_case <- 2 / 3
   expect_equal(unique(out$avg_transition_risk_best_case), expected_best_case)
   expect_equal(unique(out$avg_transition_risk_worst_case), expected_worst_case)
 })
 
 test_that("only `NA` in `transition_risk_category` gives `0` value for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
   example_data <- example_best_case_worst_case_transition_risk_profile_product_level(
-    transition_risk_category = c(NA_character_, NA_character_, NA_character_)
+    transition_risk_category = NA_character_
   )
 
   out <- create_avg_best_case_worst_case_at_product_level(example_data)

--- a/tests/testthat/test-create_avg_best_case_worst_case_at_product_level.R
+++ b/tests/testthat/test-create_avg_best_case_worst_case_at_product_level.R
@@ -1,0 +1,50 @@
+test_that("single `NA` in `transition_risk_category` gives correct values for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
+  example_data <- example_best_case_worst_case_transition_risk_profile_product_level(
+    transition_risk_category = c("low", "low", NA_character_)
+  )
+
+  out <- create_avg_best_case_worst_case_at_product_level(example_data)
+
+  expected_best_case <- 2/3
+  expected_worst_case <- 2/3
+  expect_equal(unique(out$avg_transition_risk_best_case), expected_best_case)
+  expect_equal(unique(out$avg_transition_risk_worst_case), expected_worst_case)
+})
+
+test_that("only `NA` in `transition_risk_category` gives `0` value for `avg_transition_risk_best_case` and `avg_transition_risk_worst_case`", {
+  example_data <- example_best_case_worst_case_transition_risk_profile_product_level(
+    transition_risk_category = c(NA_character_, NA_character_, NA_character_)
+  )
+
+  out <- create_avg_best_case_worst_case_at_product_level(example_data)
+
+  expected_best_case <- 0
+  expected_worst_case <- 0
+  expect_equal(unique(out$avg_transition_risk_best_case), expected_best_case)
+  expect_equal(unique(out$avg_transition_risk_worst_case), expected_worst_case)
+})
+
+
+test_that("if `transition_profile_at_product_level` lacks crucial columns, errors gracefully", {
+  example_data <- example_best_case_worst_case_transition_risk_profile_product_level()
+
+  crucial <- col_companies_id()
+  bad <- select(example_data, -all_of(crucial))
+  expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
+
+  crucial <- col_europages_product()
+  bad <- select(example_data, -all_of(crucial))
+  expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
+
+  crucial <- col_transition_risk_grouped_by()
+  bad <- select(example_data, -all_of(crucial))
+  expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
+
+  crucial <- col_transition_risk_category()
+  bad <- select(example_data, -all_of(crucial))
+  expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
+
+  crucial <- "amount_of_distinct_products"
+  bad <- select(example_data, -all_of(crucial))
+  expect_error(create_avg_best_case_worst_case_at_product_level(bad), crucial)
+})

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -1,9 +1,5 @@
 test_that("yields a 'tilt_profile'", {
-  restore <- options(list(
-    readr.show_col_types = FALSE,
-    tiltIndicatorAfter.output_co2_footprint = TRUE
-  ))
-
+  restore <- options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
   toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
     filter(activity_uuid_product_uuid != "76269c17-78d6-420b-991a-aa38c51b45b7")
   toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
@@ -49,11 +45,7 @@ test_that("yields a 'tilt_profile'", {
 
 
 test_that("outputs `NA` transition risk category for `NA` transition risk score at product level", {
-  restore <- options(list(
-    readr.show_col_types = FALSE,
-    tiltIndicatorAfter.output_co2_footprint = TRUE
-  ))
-
+  restore <- options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
   toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
     filter(activity_uuid_product_uuid != "76269c17-78d6-420b-991a-aa38c51b45b7")
   toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
@@ -150,11 +142,7 @@ test_that("outputs columns `transition_risk_category_share` and `transition_risk
 })
 
 test_that("outputs `NA` in `avg_transition_risk_best_case` and `avg_transition_risk_worst_case` for `NA` at company level if `transition_risk_score` and `transition_risk_category` are `NA` at product level", {
-  restore <- options(list(
-    readr.show_col_types = FALSE,
-    tiltIndicatorAfter.output_co2_footprint = TRUE
-  ))
-
+  restore <- options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
   toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
     filter(activity_uuid_product_uuid != "76269c17-78d6-420b-991a-aa38c51b45b7")
   toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -1,5 +1,4 @@
 test_that("yields a 'tilt_profile'", {
-  set.seed(123)
   restore <- options(list(
     readr.show_col_types = FALSE,
     tiltIndicatorAfter.output_co2_footprint = TRUE
@@ -50,7 +49,6 @@ test_that("yields a 'tilt_profile'", {
 
 
 test_that("outputs `NA` transition risk category for `NA` transition risk score at product level", {
-  set.seed(123)
   restore <- options(list(
     readr.show_col_types = FALSE,
     tiltIndicatorAfter.output_co2_footprint = TRUE
@@ -152,7 +150,6 @@ test_that("outputs columns `transition_risk_category_share` and `transition_risk
 })
 
 test_that("outputs `NA` in `avg_transition_risk_best_case` and `avg_transition_risk_worst_case` for `NA` at company level if `transition_risk_score` and `transition_risk_category` are `NA` at product level", {
-  set.seed(123)
   restore <- options(list(
     readr.show_col_types = FALSE,
     tiltIndicatorAfter.output_co2_footprint = TRUE

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -49,7 +49,7 @@ test_that("yields a 'tilt_profile'", {
 })
 
 
-test_that("outputs `NA` transition risk category for `NA` transition risk score ", {
+test_that("outputs `NA` transition risk category for `NA` transition risk score at product level", {
   set.seed(123)
   restore <- options(list(
     readr.show_col_types = FALSE,
@@ -149,4 +149,61 @@ test_that("outputs columns `transition_risk_category_share` and `transition_risk
   expected_cols <- c("transition_risk_category_share", "transition_risk_category")
 
   expect_true(all(unique(expected_cols) %in% names(company_level_output)))
+})
+
+test_that("outputs `NA` in `avg_transition_risk_best_case` and `avg_transition_risk_worst_case` for `NA` in `avg_transition_risk_equal_weight` and `transition_risk_category` at company level", {
+  set.seed(123)
+  restore <- options(list(
+    readr.show_col_types = FALSE,
+    tiltIndicatorAfter.output_co2_footprint = TRUE
+  ))
+
+  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
+  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+  toy_europages_companies <- read_csv(toy_europages_companies())
+  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  toy_isic_name <- read_csv(toy_isic_name())
+  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+
+  toy_emissions_profile <- profile_emissions(
+    companies = toy_emissions_profile_any_companies,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    europages_companies = toy_europages_companies,
+    ecoinvent_activities = toy_ecoinvent_activities,
+    ecoinvent_europages = toy_ecoinvent_europages,
+    isic = toy_isic_name
+  )
+  toy_sector_profile <- profile_sector(
+    companies = toy_sector_profile_companies,
+    scenarios = toy_sector_profile_any_scenarios,
+    europages_companies = toy_europages_companies,
+    ecoinvent_activities = toy_ecoinvent_activities,
+    ecoinvent_europages = toy_ecoinvent_europages,
+    isic = toy_isic_name
+  )
+
+  company_level_output <- transition_risk_profile(
+    emissions_profile = toy_emissions_profile,
+    sector_profile = toy_sector_profile,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
+    scenarios = toy_sector_profile_any_scenarios,
+    pivot_wider = FALSE
+  ) |>
+    unnest_company() |>
+    filter(companies_id == "nonphilosophical_llama")
+
+  # `avg_transition_risk_equal_weight` and `transition_risk_category` are `NA` for company "nonphilosophical_llama"
+  expect_true(is.na(unique(company_level_output$avg_transition_risk_equal_weight)))
+  expect_true(is.na(unique(company_level_output$transition_risk_category)))
+  # `avg_transition_risk_best_case` and `avg_transition_risk_worst_case` are `NA` as well
+  expect_true(is.na(unique(company_level_output$avg_transition_risk_best_case)))
+  expect_true(is.na(unique(company_level_output$avg_transition_risk_worst_case)))
 })


### PR DESCRIPTION
closes #257 

Dear @AnneSchoenauer @Tilmon @maurolepore 

This PR adds creates the function `best_case_worst_case_transition_risk_profile_at_company_level` (subject to name change). This function creates the columns `average_transition_risk_best_case` and `avg_transition_risk_worst_case`. It also renames a column to `avg_transition_risk_equal_weight`. Please review the logic of the output through below reprex:


``` r
library(readr, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(tiltToyData, warn.conflicts = FALSE)
library(tiltTransitionRisk, warn.conflicts = FALSE)
devtools::load_all(".")
#> ℹ Loading tiltIndicatorAfter
options(width = 5000)

set.seed(123)
restore <- options(list(
  readr.show_col_types = FALSE,
  tiltIndicatorAfter.output_co2_footprint = TRUE
))

toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent())
toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies()) |>
  mutate(companies_id = case_when(
    companies_id == "antimonarchy_canine" ~ "nonphilosophical_llama",
    TRUE ~ companies_id
  ))
toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
  mutate(companies_id = case_when(
    companies_id == "antimonarchy_canine" ~ "nonphilosophical_llama",
    TRUE ~ companies_id
  ))
toy_europages_companies <- read_csv(toy_europages_companies())
toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
toy_isic_name <- read_csv(toy_isic_name())
toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors())

toy_emissions_profile <- profile_emissions(
  companies = toy_emissions_profile_any_companies,
  co2 = toy_emissions_profile_products_ecoinvent,
  europages_companies = toy_europages_companies,
  ecoinvent_activities = toy_ecoinvent_activities,
  ecoinvent_europages = toy_ecoinvent_europages,
  isic = toy_isic_name
)

toy_sector_profile <- profile_sector(
  companies = toy_sector_profile_companies,
  scenarios = toy_sector_profile_any_scenarios,
  europages_companies = toy_europages_companies,
  ecoinvent_activities = toy_ecoinvent_activities,
  ecoinvent_europages = toy_ecoinvent_europages,
  isic = toy_isic_name
)

output <- transition_risk_profile(
  emissions_profile = toy_emissions_profile,
  sector_profile = toy_sector_profile,
  co2 = toy_emissions_profile_products_ecoinvent,
  all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
  scenarios = toy_sector_profile_any_scenarios,
  pivot_wider = FALSE
)

product <- output |> 
  unnest_product() |>
  filter(companies_id == "nonphilosophical_llama",
         benchmark_tr_score %in% c("1.5C RPS_2030_all", "1.5C RPS_2030_isic_4digit", "1.5C RPS_2030_tilt_sector")) 

product |> 
  print(n = Inf)
#> # A tibble: 9 × 28
#>   companies_id           activity_uuid_product_uuid           transition_risk_score transition_risk_low_threshold transition_risk_high_threshold transition_risk_category benchmark_tr_score        profile_ranking reduction_targets country main_activity ep_product                  matched_activity_name                                         matched_reference_product                          unit  co2e_lower co2e_upper emission_profile benchmark   tilt_sector  tilt_subsector           sector_profile scenario  year amount_of_distinct_products equal_weight best_case worst_case
#>   <chr>                  <chr>                                                <dbl>                         <dbl>                          <dbl> <chr>                    <chr>                               <dbl>             <dbl> <chr>   <chr>         <chr>                       <chr>                                                         <chr>                                              <chr>      <dbl>      <dbl> <chr>            <chr>       <chr>        <chr>                    <chr>          <chr>    <dbl>                       <int>        <dbl>     <dbl>      <dbl>
#> 1 nonphilosophical_llama 76269c17-78d6-420b-991a-aa38c51b45b7                 0.59                          0.366                          0.492 high                     1.5C RPS_2030_all                   1                  0.18 germany distributor   tent                        market for shed, large, wood, non-insulated, fire-unprotected shed, large, wood, non-insulated, fire-unprotected m2        45.5      767.    high             all         construction construction residential medium         1.5C RPS  2030                           3        0.333       0            1
#> 2 nonphilosophical_llama 833caa78-30df-4374-900f-7f88ab44075b                 0.212                         0.366                          0.492 low                      1.5C RPS_2030_all                   0.333              0.09 germany distributor   surface finishing, galvanic market for deep drawing, steel, 10000 kN press, automode      deep drawing, steel, 10000 kN press, automode      kg        -0.106      1.91  low              all         metals       other metals             low            1.5C RPS  2030                           3        0.333       0.5          0
#> 3 nonphilosophical_llama 833caa78-30df-4374-900f-7f88ab44075b                 0.212                         0.366                          0.492 low                      1.5C RPS_2030_all                   0.333              0.09 germany distributor   surface engineering         market for deep drawing, steel, 10000 kN press, automode      deep drawing, steel, 10000 kN press, automode      kg        -0.106      1.91  low              all         metals       other metals             low            1.5C RPS  2030                           3        0.333       0.5          0
#> 4 nonphilosophical_llama 76269c17-78d6-420b-991a-aa38c51b45b7                 0.59                          0.575                          0.597 medium                   1.5C RPS_2030_isic_4digit           1                  0.18 germany distributor   tent                        market for shed, large, wood, non-insulated, fire-unprotected shed, large, wood, non-insulated, fire-unprotected m2       269.       355.    high             isic_4digit construction construction residential medium         1.5C RPS  2030                           3        0.333       0            1
#> 5 nonphilosophical_llama 833caa78-30df-4374-900f-7f88ab44075b                 0.545                         0.575                          0.597 low                      1.5C RPS_2030_isic_4digit           1                  0.09 germany distributor   surface finishing, galvanic market for deep drawing, steel, 10000 kN press, automode      deep drawing, steel, 10000 kN press, automode      kg        -0.395      1.96  high             isic_4digit metals       other metals             low            1.5C RPS  2030                           3        0.333       0.5          0
#> 6 nonphilosophical_llama 833caa78-30df-4374-900f-7f88ab44075b                 0.545                         0.575                          0.597 low                      1.5C RPS_2030_isic_4digit           1                  0.09 germany distributor   surface engineering         market for deep drawing, steel, 10000 kN press, automode      deep drawing, steel, 10000 kN press, automode      kg        -0.395      1.96  high             isic_4digit metals       other metals             low            1.5C RPS  2030                           3        0.333       0.5          0
#> 7 nonphilosophical_llama 76269c17-78d6-420b-991a-aa38c51b45b7                 0.59                          0.492                          0.597 medium                   1.5C RPS_2030_tilt_sector           1                  0.18 germany distributor   tent                        market for shed, large, wood, non-insulated, fire-unprotected shed, large, wood, non-insulated, fire-unprotected m2        87.7      787.    high             tilt_sector construction construction residential medium         1.5C RPS  2030                           3        0.333       0            1
#> 8 nonphilosophical_llama 833caa78-30df-4374-900f-7f88ab44075b                 0.295                         0.492                          0.597 low                      1.5C RPS_2030_tilt_sector           0.5                0.09 germany distributor   surface finishing, galvanic market for deep drawing, steel, 10000 kN press, automode      deep drawing, steel, 10000 kN press, automode      kg         0.491      0.949 medium           tilt_sector metals       other metals             low            1.5C RPS  2030                           3        0.333       0.5          0
#> 9 nonphilosophical_llama 833caa78-30df-4374-900f-7f88ab44075b                 0.295                         0.492                          0.597 low                      1.5C RPS_2030_tilt_sector           0.5                0.09 germany distributor   surface engineering         market for deep drawing, steel, 10000 kN press, automode      deep drawing, steel, 10000 kN press, automode      kg         0.491      0.949 medium           tilt_sector metals       other metals             low            1.5C RPS  2030                           3        0.333       0.5          0

company <- output |> 
  unnest_company() |>
  filter(companies_id == "nonphilosophical_llama",
         benchmark_tr_score_avg %in% c("1.5C RPS_2030_all", "1.5C RPS_2030_isic_4digit", "1.5C RPS_2030_tilt_sector"))

company |> 
  print(n = Inf)
#> # A tibble: 12 × 17
#>    companies_id           country main_activity benchmark_tr_score_avg    benchmark   emission_profile emission_profile_share profile_ranking_avg co2_avg scenario year  reduction_targets_avg avg_transition_risk_equal_weight transition_risk_category transition_risk_category_share avg_transition_risk_best_case avg_transition_risk_worst_case
#>    <chr>                  <chr>   <chr>         <chr>                     <chr>       <chr>                             <dbl>               <dbl>   <dbl> <chr>    <chr>                 <dbl>                            <dbl> <chr>                                             <dbl>                         <dbl>                          <dbl>
#>  1 nonphilosophical_llama germany distributor   1.5C RPS_2030_all         all         high                              0.333               0.556    101. 1.5C RPS 2030                   0.12                            0.338 high                                              0.333                         0.212                           0.59
#>  2 nonphilosophical_llama germany distributor   1.5C RPS_2030_all         all         medium                            0                   0.556    101. 1.5C RPS 2030                   0.12                            0.338 medium                                            0                             0.212                           0.59
#>  3 nonphilosophical_llama germany distributor   1.5C RPS_2030_all         all         low                               0.667               0.556    101. 1.5C RPS 2030                   0.12                            0.338 low                                               0.667                         0.212                           0.59
#>  4 nonphilosophical_llama germany distributor   1.5C RPS_2030_all         all         <NA>                              0                   0.556    101. 1.5C RPS 2030                   0.12                            0.338 <NA>                                              0                             0.212                           0.59
#>  5 nonphilosophical_llama germany distributor   1.5C RPS_2030_isic_4digit isic_4digit high                              1                   1        101. 1.5C RPS 2030                   0.12                            0.56  high                                              0                             0.545                           0.59
#>  6 nonphilosophical_llama germany distributor   1.5C RPS_2030_isic_4digit isic_4digit medium                            0                   1        101. 1.5C RPS 2030                   0.12                            0.56  medium                                            0.333                         0.545                           0.59
#>  7 nonphilosophical_llama germany distributor   1.5C RPS_2030_isic_4digit isic_4digit low                               0                   1        101. 1.5C RPS 2030                   0.12                            0.56  low                                               0.667                         0.545                           0.59
#>  8 nonphilosophical_llama germany distributor   1.5C RPS_2030_isic_4digit isic_4digit <NA>                              0                   1        101. 1.5C RPS 2030                   0.12                            0.56  <NA>                                              0                             0.545                           0.59
#>  9 nonphilosophical_llama germany distributor   1.5C RPS_2030_tilt_sector tilt_sector high                              0.333               0.667    101. 1.5C RPS 2030                   0.12                            0.393 high                                              0                             0.295                           0.59
#> 10 nonphilosophical_llama germany distributor   1.5C RPS_2030_tilt_sector tilt_sector medium                            0.667               0.667    101. 1.5C RPS 2030                   0.12                            0.393 medium                                            0.333                         0.295                           0.59
#> 11 nonphilosophical_llama germany distributor   1.5C RPS_2030_tilt_sector tilt_sector low                               0                   0.667    101. 1.5C RPS 2030                   0.12                            0.393 low                                               0.667                         0.295                           0.59
#> 12 nonphilosophical_llama germany distributor   1.5C RPS_2030_tilt_sector tilt_sector <NA>                              0                   0.667    101. 1.5C RPS 2030                   0.12                            0.393 <NA>                                              0                             0.295                           0.59
```

<sup>Created on 2024-06-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
