### PR TITLE
Fix test warnings

### DIFF
--- a/R/utils-best_case_worst_case.R
+++ b/R/utils-best_case_worst_case.R
@@ -36,7 +36,7 @@ compute_min_risk_category_per_company_benchmark <- function(data, col_risk, col_
       col_risk = col_risk,
       risk_order = c("low", "medium", "high")
     ),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 
@@ -47,7 +47,7 @@ compute_max_risk_category_per_company_benchmark <- function(data, col_risk, col_
       col_risk = col_risk,
       risk_order = c("high", "medium", "low")
     ),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 
@@ -72,14 +72,14 @@ compute_worst_risk <- function(data, col_risk) {
 compute_count_best_case_products_per_company_benchmark <- function(data, col_group_by) {
   mutate(data,
     count_best_case_products_per_company_benchmark = sum(.data$best_risk),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 
 compute_count_worst_case_products_per_company_benchmark <- function(data, col_group_by) {
   mutate(data,
     count_worst_case_products_per_company_benchmark = sum(.data$worst_risk),
-    .by = c(col_companies_id(), col_group_by)
+    .by = all_of(c(col_companies_id(), col_group_by))
   )
 }
 


### PR DESCRIPTION
Merges into `257_avg_transition_risk_best_case_worst_case`

This PR fixes many warnings I see when I run `devtools::test().

--

RE https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/269#issuecomment-2186208871

When you run `devtools::test()` you get 0 errors, 0 warnings, 0 notes?

Not sure why but you may try in a fresh envorinment. Maybe try posit.cloud, GitHub codespaces, or Docker.

But you can also reproduce the warning in a reprex. 

``` r
library(dplyr, warn.conflicts = FALSE)

good <- function(data) {
  col <- "cyl"
  mutate(data, x = cyl, .by = all_of(col))
}

bad <- function(data) {
  col <- "cyl"
  mutate(data, x = cyl, .by = col)
}



data <- mtcars[1:3, 1:3]

# No warning
data |> good()
#>                mpg cyl disp x
#> Mazda RX4     21.0   6  160 6
#> Mazda RX4 Wag 21.0   6  160 6
#> Datsun 710    22.8   4  108 4

# Warning
data |> bad()
#> Warning: Using an external vector in selections was deprecated in tidyselect 1.1.0.
#> ℹ Please use `all_of()` or `any_of()` instead.
#>   # Was:
#>   data %>% select(col)
#> 
#>   # Now:
#>   data %>% select(all_of(col))
#> 
#> See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
#>                mpg cyl disp x
#> Mazda RX4     21.0   6  160 6
#> Mazda RX4 Wag 21.0   6  160 6
#> Datsun 710    22.8   4  108 4
```

The warning is a bit missleading. The first part is informative:
```r
#> ℹ Please use `all_of()` or `any_of()` instead.
```
But the second part steers you in the wrong direction. It mentions `select()` but here the fix must be in `.by = `.

