### PR TITLE
Add function `limit_transition_risk_score_between_0_and_1()`

### DIFF
--- a/R/score_transition_risk.R
+++ b/R/score_transition_risk.R
@@ -69,6 +69,7 @@ score_transition_risk <-
     trs_product <-
       full_join_emmissions_sector(trs_emissions, trs_sector) |>
       create_tr_benchmarks_tr_score() |>
+      limit_transition_risk_score_between_0_and_1() |>
       select(-c("scenario_year", "benchmark")) |>
       left_join(
         union_emissions_sector_rows,
@@ -115,4 +116,8 @@ create_trs_average <- function(data) {
     transition_risk_score_avg = round(mean(.data$transition_risk_score, na.rm = TRUE), 3),
     .by = c("companies_id", "benchmark_tr_score")
   )
+}
+
+limit_transition_risk_score_between_0_and_1 <- function(data) {
+  mutate(data, transition_risk_score = pmin(pmax(data$transition_risk_score, 0), 1))
 }

--- a/tests/testthat/test-score_transition_risk.R
+++ b/tests/testthat/test-score_transition_risk.R
@@ -232,8 +232,8 @@ test_that("limits `transition_risk_score` between 0 and 1", {
     ) |>
     unnest_product()
 
-  # Due to large positive and negative `reduction_targets` values, `transition_risk_score`
-  # should not be more than 1 and less than 0.
+  # Due to large positive and negative `reduction_targets` values,
+  # `transition_risk_score` should not be more than 1 and less than 0.
   expected_values <- c(0, 1)
   expect_equal(unique(out$transition_risk_score), expected_values)
 })

--- a/tests/testthat/test-score_transition_risk.R
+++ b/tests/testthat/test-score_transition_risk.R
@@ -215,3 +215,25 @@ test_that("characterize commit 663d12", {
     hasName("benchmark_tr_score_avg") |>
     expect_true()
 })
+
+test_that("limits `transition_risk_score` between 0 and 1", {
+  emissions_profile_at_product_level <-
+    example_emissions_profile_at_product_level() |>
+    filter(companies_id == "antimonarchy_canine")
+  sector_profile_at_product_level <-
+    example_sector_profile_at_product_level() |>
+    filter(companies_id == "antimonarchy_canine") |>
+    mutate(reduction_targets = c(-100, -100, 100, 100))
+
+  out <-
+    score_transition_risk(
+      emissions_profile_at_product_level,
+      sector_profile_at_product_level
+    ) |>
+    unnest_product()
+
+  # Due to large positive and negative `reduction_targets` values, `transition_risk_score`
+  # should not be more than 1 and less than 0.
+  expected_values <- c(0, 1)
+  expect_equal(unique(out$transition_risk_score), expected_values)
+})


### PR DESCRIPTION
closes #262 

Dear @maurolepore,

This PR limits the transition risk scores between 0 and 1. Please review! Thanks!

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [x] Document user-facing changes in the changelog.
