### PR TITLE
`transition_risk_profile` outputs `co2_footprint` at product level and `co2_avg` at company level if `*.output_co2_footprint = TRUE`

### DIFF
--- a/R/pivot_wider_transition_risk_profile.R
+++ b/R/pivot_wider_transition_risk_profile.R
@@ -2,6 +2,7 @@
 #'
 #' @param pivot_wider Logical. Pivot the output at company level to a wide
 #'   format?
+#' @param include_co2 Logical. Include `co2_*` columns ?
 #'
 #' @return `r document_tilt_profile()`
 #' @export
@@ -61,7 +62,10 @@
 #' ) |>
 #'   add_transition_risk_category_at_company_level() |>
 #'   best_case_worst_case_transition_risk_profile_at_company_level() |>
-#'   pivot_wider_transition_risk_profile(pivot_wider = pivot_wider) |>
+#'   pivot_wider_transition_risk_profile(
+#'     pivot_wider = pivot_wider,
+#'     include_co2 = TRUE
+#'   ) |>
 #'   unnest_company()
 #' long
 #'
@@ -78,14 +82,19 @@
 #' ) |>
 #'   add_transition_risk_category_at_company_level() |>
 #'   best_case_worst_case_transition_risk_profile_at_company_level() |>
-#'   pivot_wider_transition_risk_profile(pivot_wider = pivot_wider) |>
+#'   pivot_wider_transition_risk_profile(
+#'     pivot_wider = pivot_wider,
+#'     include_co2 = TRUE
+#'   ) |>
 #'   unnest_company()
 #' wide
 #'
 #' # Cleanup
 #' options(restore)
 #' }
-pivot_wider_transition_risk_profile <- function(data, pivot_wider = FALSE) {
+pivot_wider_transition_risk_profile <- function(data,
+                                                pivot_wider = FALSE,
+                                                include_co2 = FALSE) {
   product <- data |>
     unnest_product()
 
@@ -94,9 +103,11 @@ pivot_wider_transition_risk_profile <- function(data, pivot_wider = FALSE) {
 
   if (pivot_wider) {
     emission_profile_company <- company |>
-      select_emissions_profile_pivot_cols() |>
+      select_emissions_profile_pivot_cols(include_co2 = include_co2) |>
       exclude_subset_cols_then_pivot_wider(
-        subset_cols = select_subset_emissions_profile_id_cols(),
+        subset_cols = select_subset_emissions_profile_id_cols(
+          include_co2 = include_co2
+        ),
         names_from = "emission_profile",
         names_prefix = "emission_category_",
         values_from = "emission_profile_share"
@@ -161,7 +172,7 @@ exclude_subset_cols_then_pivot_wider <- function(data,
     )
 }
 
-select_subset_emissions_profile_id_cols <- function(data) {
+select_subset_emissions_profile_id_cols <- function(data, include_co2 = FALSE) {
   c(
     "companies_id",
     "country",
@@ -170,14 +181,15 @@ select_subset_emissions_profile_id_cols <- function(data) {
     "profile_ranking_avg",
     "postcode",
     "address",
+    if (include_co2) "co2_avg",
     "min_headcount",
     "max_headcount"
   )
 }
 
-select_emissions_profile_pivot_cols <- function(data) {
+select_emissions_profile_pivot_cols <- function(data, include_co2 = FALSE) {
   select(data, c(
-    select_subset_emissions_profile_id_cols(),
+    select_subset_emissions_profile_id_cols(include_co2 = include_co2),
     "emission_profile",
     "emission_profile_share"
   ))

--- a/R/score_transition_risk_and_polish.R
+++ b/R/score_transition_risk_and_polish.R
@@ -3,7 +3,7 @@
 #' @param emissions_profile Nested data frame. The output of
 #'   `profile_emissions()`.
 #' @param sector_profile Nested data frame. The output of `profile_sector()`.
-#' @param exclude_co2 Logical. Exclude `co2_*` columns ?
+#' @param include_co2 Logical. Include `co2_*` columns ?
 #'
 #' @return A data frame with the column `companies_id`, and the nested
 #'   columns`product` and `company` holding the outputs at product and company
@@ -50,7 +50,10 @@
 #'   isic = toy_isic_name
 #' )
 #'
-#' result <- score_transition_risk_and_polish(emissions_profile, sector_profile)
+#' result <- score_transition_risk_and_polish(emissions_profile,
+#'   sector_profile,
+#'   include_co2 = TRUE
+#' )
 #'
 #' result |> unnest_product()
 #'
@@ -60,13 +63,13 @@
 #' options(restore)
 score_transition_risk_and_polish <- function(emissions_profile,
                                              sector_profile,
-                                             exclude_co2 = FALSE) {
+                                             include_co2 = FALSE) {
   transition_risk_score <- score_transition_risk(
     unnest_product(emissions_profile),
     unnest_product(sector_profile)
   )
 
-  if (!exclude_co2) {
+  if (include_co2) {
     hint <- "Do you need `options(tiltIndicatorAfter.output_co2_footprint = TRUE)`?"
     unnest_product(emissions_profile) |> check_col("co2_footprint", hint)
   }
@@ -95,7 +98,7 @@ score_transition_risk_and_polish <- function(emissions_profile,
         "max_headcount",
         "emissions_profile_best_case",
         "emissions_profile_worst_case",
-        if (!exclude_co2) "co2_footprint"
+        if (include_co2) "co2_footprint"
       )
     )
   select_sector_profile_product <- unnest_product(sector_profile) |>
@@ -149,7 +152,7 @@ score_transition_risk_and_polish <- function(emissions_profile,
         "emission_profile",
         "emission_profile_share",
         "profile_ranking_avg",
-        if (!exclude_co2) "co2_avg"
+        if (include_co2) "co2_avg"
       )
     )
 

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -84,23 +84,22 @@ transition_risk_profile <- function(emissions_profile,
     sector_profile,
     co2,
     all_activities_scenario_sectors,
-    scenarios,
-    exclude_co2 = pivot_wider
+    scenarios
   ) |>
     add_transition_risk_category_at_company_level() |>
     best_case_worst_case_transition_risk_profile_at_company_level() |>
-    pivot_wider_transition_risk_profile(pivot_wider = pivot_wider)
+    pivot_wider_transition_risk_profile(pivot_wider = pivot_wider,
+                                        include_co2 = option_output_co2_footprint())
 }
 
 transition_risk_profile_impl <- function(emissions_profile,
                                          sector_profile,
                                          co2,
                                          all_activities_scenario_sectors,
-                                         scenarios,
-                                         exclude_co2 = FALSE) {
+                                         scenarios) {
   transition_risk_scores <- score_transition_risk_and_polish(emissions_profile,
     sector_profile,
-    exclude_co2 = exclude_co2
+    include_co2 = option_output_co2_footprint()
   )
   transition_risk_thresholds <- add_thresholds_transition_risk(
     co2,

--- a/man/pivot_wider_transition_risk_profile.Rd
+++ b/man/pivot_wider_transition_risk_profile.Rd
@@ -4,11 +4,17 @@
 \alias{pivot_wider_transition_risk_profile}
 \title{Calculate the indicator "transition risk profile"}
 \usage{
-pivot_wider_transition_risk_profile(data, pivot_wider = FALSE)
+pivot_wider_transition_risk_profile(
+  data,
+  pivot_wider = FALSE,
+  include_co2 = FALSE
+)
 }
 \arguments{
 \item{pivot_wider}{Logical. Pivot the output at company level to a wide
 format?}
+
+\item{include_co2}{Logical. Include \verb{co2_*} columns ?}
 }
 \value{
 A data frame with the column \code{companies_id}, and the list columns \code{product} and \code{company} holding the outputs at product and company level.
@@ -70,7 +76,10 @@ long <- transition_risk_profile_impl(
 ) |>
   add_transition_risk_category_at_company_level() |>
   best_case_worst_case_transition_risk_profile_at_company_level() |>
-  pivot_wider_transition_risk_profile(pivot_wider = pivot_wider) |>
+  pivot_wider_transition_risk_profile(
+    pivot_wider = pivot_wider,
+    include_co2 = TRUE
+  ) |>
   unnest_company()
 long
 
@@ -87,7 +96,10 @@ wide <- transition_risk_profile_impl(
 ) |>
   add_transition_risk_category_at_company_level() |>
   best_case_worst_case_transition_risk_profile_at_company_level() |>
-  pivot_wider_transition_risk_profile(pivot_wider = pivot_wider) |>
+  pivot_wider_transition_risk_profile(
+    pivot_wider = pivot_wider,
+    include_co2 = TRUE
+  ) |>
   unnest_company()
 wide
 

--- a/man/score_transition_risk_and_polish.Rd
+++ b/man/score_transition_risk_and_polish.Rd
@@ -7,7 +7,7 @@
 score_transition_risk_and_polish(
   emissions_profile,
   sector_profile,
-  exclude_co2 = FALSE
+  include_co2 = FALSE
 )
 }
 \arguments{
@@ -16,7 +16,7 @@ score_transition_risk_and_polish(
 
 \item{sector_profile}{Nested data frame. The output of \code{profile_sector()}.}
 
-\item{exclude_co2}{Logical. Exclude \verb{co2_*} columns ?}
+\item{include_co2}{Logical. Include \verb{co2_*} columns ?}
 }
 \value{
 A data frame with the column \code{companies_id}, and the nested
@@ -65,7 +65,10 @@ sector_profile <- profile_sector(
   isic = toy_isic_name
 )
 
-result <- score_transition_risk_and_polish(emissions_profile, sector_profile)
+result <- score_transition_risk_and_polish(emissions_profile,
+  sector_profile,
+  include_co2 = TRUE
+)
 
 result |> unnest_product()
 

--- a/tests/testthat/test-score_transition_risk_and_polish.R
+++ b/tests/testthat/test-score_transition_risk_and_polish.R
@@ -33,7 +33,7 @@ test_that("outputs results both at product and company level", {
   expect_named(out, c("companies_id", "product", "company"))
 })
 
-test_that("with `*.output_co2_footprint` unset, `exclude_co2 = FALSE` yields an error", {
+test_that("with `*.output_co2_footprint` unset, `include_co2 = TRUE` yields an error", {
   unset <- NULL
   withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = unset))
 
@@ -66,12 +66,12 @@ test_that("with `*.output_co2_footprint` unset, `exclude_co2 = FALSE` yields an 
   )
 
   expect_error(
-    score_transition_risk_and_polish(emissions_profile, sector_profile),
+    score_transition_risk_and_polish(emissions_profile, sector_profile, include_co2 = TRUE),
     "tiltIndicatorAfter.output_co2_footprint"
   )
 })
 
-test_that("with `*.output_co2_footprint` unset, `exclude_co2 = TRUE` yields no error", {
+test_that("with `*.output_co2_footprint` unset, `include_co2 = FALSE` yields no error", {
   unset <- NULL
   withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = unset))
 
@@ -106,8 +106,7 @@ test_that("with `*.output_co2_footprint` unset, `exclude_co2 = TRUE` yields no e
   expect_no_error(
     score_transition_risk_and_polish(
       emissions_profile,
-      sector_profile,
-      exclude_co2 = TRUE
+      sector_profile
     )
   )
 })

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -284,55 +284,6 @@ test_that("is sensitive to `pivot_wider`", {
   expect_true(long_transition_risk_cols < wide_transition_risk_cols)
 })
 
-
-test_that("with `*.output_co2_footprint` unset, `pivot_wider = FALSE` yields an error", {
-  unset <- NULL
-  withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = unset))
-
-  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
-    filter(activity_uuid_product_uuid != "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
-  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
-  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_europages_companies <- read_csv(toy_europages_companies())
-  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
-  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
-  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
-  toy_isic_name <- read_csv(toy_isic_name())
-  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-
-  toy_emissions_profile <- profile_emissions(
-    companies = toy_emissions_profile_any_companies,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-  toy_sector_profile <- profile_sector(
-    companies = toy_sector_profile_companies,
-    scenarios = toy_sector_profile_any_scenarios,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-
-  expect_error(
-    transition_risk_profile(
-      emissions_profile = toy_emissions_profile,
-      sector_profile = toy_sector_profile,
-      co2 = toy_emissions_profile_products_ecoinvent,
-      all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-      scenarios = toy_sector_profile_any_scenarios,
-      pivot_wider = FALSE
-    ),
-    "tiltIndicatorAfter.output_co2_footprint"
-  )
-})
-
 test_that("with `*.output_co2_footprint` unset, `pivot_wider = TRUE` yields no error", {
   unset <- NULL
   withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = unset))
@@ -378,6 +329,122 @@ test_that("with `*.output_co2_footprint` unset, `pivot_wider = TRUE` yields no e
       pivot_wider = TRUE
     )
   )
+})
+
+test_that("doesn't output `co2_footprint` at product level and `co2_avg` at company level if `*.output_co2_footprint` unset", {
+  unset <- NULL
+  withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = unset))
+
+  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
+  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+  toy_europages_companies <- read_csv(toy_europages_companies())
+  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  toy_isic_name <- read_csv(toy_isic_name())
+  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+
+  toy_emissions_profile <- profile_emissions(
+    companies = toy_emissions_profile_any_companies,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    europages_companies = toy_europages_companies,
+    ecoinvent_activities = toy_ecoinvent_activities,
+    ecoinvent_europages = toy_ecoinvent_europages,
+    isic = toy_isic_name
+  )
+  toy_sector_profile <- profile_sector(
+    companies = toy_sector_profile_companies,
+    scenarios = toy_sector_profile_any_scenarios,
+    europages_companies = toy_europages_companies,
+    ecoinvent_activities = toy_ecoinvent_activities,
+    ecoinvent_europages = toy_ecoinvent_europages,
+    isic = toy_isic_name
+  )
+
+  long <- transition_risk_profile(
+    emissions_profile = toy_emissions_profile,
+    sector_profile = toy_sector_profile,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
+    scenarios = toy_sector_profile_any_scenarios
+  )
+
+  wide <- transition_risk_profile(
+    emissions_profile = toy_emissions_profile,
+    sector_profile = toy_sector_profile,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
+    scenarios = toy_sector_profile_any_scenarios,
+    pivot_wider = TRUE
+  )
+
+  expect_false("co2_footprint" %in% names(unnest_product(long)))
+  expect_false("co2_avg" %in% names(unnest_company(long)))
+  expect_false("co2_footprint" %in% names(unnest_product(wide)))
+  expect_false("co2_avg" %in% names(unnest_company(wide)))
+})
+
+
+test_that("outputs `co2_footprint` at product level and `co2_avg` at company level if `*.output_co2_footprint = TRUE`", {
+  withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
+
+  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
+  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
+  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+  toy_europages_companies <- read_csv(toy_europages_companies())
+  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
+  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
+  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
+  toy_isic_name <- read_csv(toy_isic_name())
+  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
+    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
+
+  toy_emissions_profile <- profile_emissions(
+    companies = toy_emissions_profile_any_companies,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    europages_companies = toy_europages_companies,
+    ecoinvent_activities = toy_ecoinvent_activities,
+    ecoinvent_europages = toy_ecoinvent_europages,
+    isic = toy_isic_name
+  )
+  toy_sector_profile <- profile_sector(
+    companies = toy_sector_profile_companies,
+    scenarios = toy_sector_profile_any_scenarios,
+    europages_companies = toy_europages_companies,
+    ecoinvent_activities = toy_ecoinvent_activities,
+    ecoinvent_europages = toy_ecoinvent_europages,
+    isic = toy_isic_name
+  )
+
+  long <- transition_risk_profile(
+    emissions_profile = toy_emissions_profile,
+    sector_profile = toy_sector_profile,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
+    scenarios = toy_sector_profile_any_scenarios
+  )
+
+  wide <- transition_risk_profile(
+    emissions_profile = toy_emissions_profile,
+    sector_profile = toy_sector_profile,
+    co2 = toy_emissions_profile_products_ecoinvent,
+    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
+    scenarios = toy_sector_profile_any_scenarios,
+    pivot_wider = TRUE
+  )
+
+  expect_true("co2_footprint" %in% names(unnest_product(long)))
+  expect_true("co2_avg" %in% names(unnest_company(long)))
+  expect_true("co2_footprint" %in% names(unnest_product(wide)))
+  expect_true("co2_avg" %in% names(unnest_company(wide)))
 })
 
 test_that("with `pivot_wider = TRUE`, at company level the `emission*` column are of type double", {
@@ -428,53 +495,6 @@ test_that("with `pivot_wider = TRUE`, at company level the `emission*` column ar
     unlist() |>
     unique()
   expect_equal(type, "double")
-})
-
-test_that("outputs `co2_footprint` at product level and `co2_avg` at company level if `pivot_wider = FALSE`", {
-  withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
-
-  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
-  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
-  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_europages_companies <- read_csv(toy_europages_companies())
-  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
-  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
-  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
-  toy_isic_name <- read_csv(toy_isic_name())
-  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-
-  toy_emissions_profile <- profile_emissions(
-    companies = toy_emissions_profile_any_companies,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-  toy_sector_profile <- profile_sector(
-    companies = toy_sector_profile_companies,
-    scenarios = toy_sector_profile_any_scenarios,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-
-  output <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
-  )
-
-  expect_true("co2_footprint" %in% names(unnest_product(output)))
-  expect_true("co2_avg" %in% names(unnest_company(output)))
 })
 
 test_that("the output at product level has columns matching `postcode`, `address`, `min_headcount`, `max_headcount`, `emissions_profile_best_case`, `emissions_profile_worst_case`, `transition_risk_profile_best_case`, and `transition_risk_profile_worst_case`", {


### PR DESCRIPTION
closes [issue](https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/187)

Dear @AnneSchoenauer @Tilmon @maurolepore,

According to the old code, we can't output `co2_footprint` and `co2_avg` from `transition_risk_profile` if other columns are converted into wide format. After discussion with @AnneSchoenauer, we came to the conclusion that co2 columns should be visible in the output tables irrespective of other columns' wide format. Therefore, this PR removes the dependency of co2 columns on wider format option and also ensures that we can choose whether we want the co2 columns in the final output using the `*.output_co2_footprint` option. 

You can also check the same using below reprex:

``` r
library(readr, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(tiltToyData, warn.conflicts = FALSE)
library(tiltTransitionRisk, warn.conflicts = FALSE)
devtools::load_all(".")
#> ℹ Loading tiltIndicatorAfter
options(width = 5000)

set.seed(123)
restore <- options(list(
  readr.show_col_types = FALSE,
  tiltIndicatorAfter.output_co2_footprint = TRUE
))

toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
  filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
  filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
toy_europages_companies <- read_csv(toy_europages_companies())
toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
toy_isic_name <- read_csv(toy_isic_name())
toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
  filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")

toy_emissions_profile <- profile_emissions(
  companies = toy_emissions_profile_any_companies,
  co2 = toy_emissions_profile_products_ecoinvent,
  europages_companies = toy_europages_companies,
  ecoinvent_activities = toy_ecoinvent_activities,
  ecoinvent_europages = toy_ecoinvent_europages,
  isic = toy_isic_name
)
toy_sector_profile <- profile_sector(
  companies = toy_sector_profile_companies,
  scenarios = toy_sector_profile_any_scenarios,
  europages_companies = toy_europages_companies,
  ecoinvent_activities = toy_ecoinvent_activities,
  ecoinvent_europages = toy_ecoinvent_europages,
  isic = toy_isic_name
)

long <- transition_risk_profile(
  emissions_profile = toy_emissions_profile,
  sector_profile = toy_sector_profile,
  co2 = toy_emissions_profile_products_ecoinvent,
  all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
  scenarios = toy_sector_profile_any_scenarios
)

wide <- transition_risk_profile(
  emissions_profile = toy_emissions_profile,
  sector_profile = toy_sector_profile,
  co2 = toy_emissions_profile_products_ecoinvent,
  all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
  scenarios = toy_sector_profile_any_scenarios,
  pivot_wider = TRUE
)

# "co2_footprint" at product level in long format
names(select(unnest_product(long), tidyselect::matches("co2")))
#> [1] "co2e_lower"    "co2e_upper"    "co2_footprint"

# "co2_avg" at company level in long format
names(select(unnest_company(long), tidyselect::matches("co2")))
#> [1] "co2_avg"

# "co2_footprint" at product level in wide format
names(select(unnest_product(wide), tidyselect::matches("co2")))
#> [1] "co2e_lower"    "co2e_upper"    "co2_footprint"

# "co2_avg" at company level in wide format
names(select(unnest_company(wide), tidyselect::matches("co2")))
#> [1] "co2_avg"
```

<sup>Created on 2024-07-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
