### PR TITLE
Add remaining columns at product and company level for `transition_risk_profile()` indicator 

### DIFF
--- a/R/pivot_wider_transition_risk_profile.R
+++ b/R/pivot_wider_transition_risk_profile.R
@@ -175,6 +175,7 @@ exclude_subset_cols_then_pivot_wider <- function(data,
 select_subset_emissions_profile_id_cols <- function(data, include_co2 = FALSE) {
   c(
     "companies_id",
+    "company_name",
     "country",
     "main_activity",
     "benchmark",

--- a/R/score_transition_risk_and_polish.R
+++ b/R/score_transition_risk_and_polish.R
@@ -98,6 +98,10 @@ score_transition_risk_and_polish <- function(emissions_profile,
         "max_headcount",
         "emissions_profile_best_case",
         "emissions_profile_worst_case",
+        "isic_4digit",
+        "matching_certainty",
+        "company_name",
+        "emissions_profile_equal_weight",
         if (include_co2) "co2_footprint"
       )
     )
@@ -142,6 +146,7 @@ score_transition_risk_and_polish <- function(emissions_profile,
     select(
       c(
         "companies_id",
+        "company_name",
         "country",
         "main_activity",
         "postcode",

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -497,7 +497,7 @@ test_that("with `pivot_wider = TRUE`, at company level the `emission*` column ar
   expect_equal(type, "double")
 })
 
-test_that("the output at product level has columns matching `postcode`, `address`, `min_headcount`, `max_headcount`, `emissions_profile_best_case`, `emissions_profile_worst_case`, `transition_risk_profile_best_case`, and `transition_risk_profile_worst_case`", {
+test_that("the output at product level has all the new required columns (#189)", {
   toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
     filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
   toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
@@ -547,9 +547,13 @@ test_that("the output at product level has columns matching `postcode`, `address
   expect_true(any(matches_name(product, "emissions_profile_worst_case")))
   expect_true(any(matches_name(product, "transition_risk_profile_best_case")))
   expect_true(any(matches_name(product, "transition_risk_profile_worst_case")))
+  expect_true(any(matches_name(product, "isic_4digit")))
+  expect_true(any(matches_name(product, "matching_certainty")))
+  expect_true(any(matches_name(product, "company_name")))
+  expect_true(any(matches_name(product, "emissions_profile_equal_weight")))
 })
 
-test_that("the output at company level has columns matching `postcode`, `address`, `min_headcount`, and `max_headcount`", {
+test_that("the output at company level has has all the new required columns (#189)", {
   toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
     filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
   toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
@@ -595,4 +599,5 @@ test_that("the output at company level has columns matching `postcode`, `address
   expect_true(any(matches_name(company, "address")))
   expect_true(any(matches_name(company, "min_headcount")))
   expect_true(any(matches_name(company, "max_headcount")))
+  expect_true(any(matches_name(company, "company")))
 })


### PR DESCRIPTION
Relates to [issue](https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/189)

According to the [excel sheet](https://docs.google.com/spreadsheets/d/1e5QUcHBb6m9AcgHEK59RrFaTC69-MZ-t/edit?gid=424568592#gid=424568592), there are some columns which are still needed to be added at product and company level. This PR adds these columns.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [ ] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
