### PR TITLE
Add function `relocate_transition_risk_profile_cols()` to relocate output columns of transition risk profile

### DIFF
--- a/R/relocate_transition_risk_profile_cols.R
+++ b/R/relocate_transition_risk_profile_cols.R
@@ -1,0 +1,132 @@
+relocate_transition_risk_profile_cols <- function(
+    data,
+    include_co2 = FALSE,
+    pivot_wider = FALSE) {
+  product <- data |>
+    unnest_product() |>
+    relocate_transition_risk_profile_cols_at_product_level(
+      include_co2 = include_co2
+    )
+
+  company <- data |>
+    unnest_company() |>
+    relocate_transition_risk_profile_cols_at_company_level(
+      include_co2 = include_co2,
+      pivot_wider = pivot_wider
+    )
+
+  tilt_profile(nest_levels(product, company))
+}
+
+relocate_transition_risk_profile_cols_at_product_level <- function(
+    data,
+    include_co2 = FALSE) {
+  data |>
+    relocate(
+      "companies_id",
+      "company_name",
+      "country",
+      "postcode",
+      "address",
+      "main_activity",
+      "ep_product",
+      "matched_activity_name",
+      "matched_reference_product",
+      "matching_certainty",
+      if (include_co2) "co2_footprint",
+      "unit",
+      "isic_4digit",
+      "tilt_sector",
+      "tilt_subsector",
+      "benchmark",
+      "co2e_lower",
+      "co2e_upper",
+      "profile_ranking",
+      "emission_profile",
+      "emissions_profile_equal_weight",
+      "emissions_profile_best_case",
+      "emissions_profile_worst_case",
+      "scenario",
+      "year",
+      "reduction_targets",
+      "sector_profile",
+      "benchmark_tr_score",
+      "transition_risk_score",
+      "transition_risk_low_threshold",
+      "transition_risk_high_threshold",
+      "transition_risk_category",
+      "transition_risk_profile_equal_weight",
+      "transition_risk_profile_best_case",
+      "transition_risk_profile_worst_case",
+      "amount_of_distinct_products",
+      "min_headcount",
+      "max_headcount"
+    )
+}
+
+relocate_transition_risk_profile_cols_at_company_level <- function(
+    data,
+    pivot_wider = FALSE,
+    include_co2 = FALSE) {
+  if (pivot_wider) {
+    data |>
+      relocate(
+        "companies_id",
+        "company_name",
+        "country",
+        if (include_co2) "co2_avg",
+        "benchmark",
+        "profile_ranking_avg",
+        "avg_profile_ranking_best_case",
+        "avg_profile_ranking_worst_case",
+        "emission_category_low",
+        "emission_category_medium",
+        "emission_category_high",
+        "emission_category_NA",
+        "scenario",
+        "year",
+        "reduction_targets_avg",
+        "sector_category_low",
+        "sector_category_medium",
+        "sector_category_high",
+        "sector_category_NA",
+        "benchmark_tr_score_avg",
+        "avg_transition_risk_equal_weight",
+        "avg_transition_risk_best_case",
+        "avg_transition_risk_worst_case",
+        "postcode",
+        "address",
+        "main_activity",
+        "min_headcount",
+        "max_headcount"
+      )
+  } else {
+    data |>
+      relocate(
+        "companies_id",
+        "company_name",
+        "country",
+        if (include_co2) "co2_avg",
+        "benchmark",
+        "profile_ranking_avg",
+        "avg_profile_ranking_best_case",
+        "avg_profile_ranking_worst_case",
+        "emission_profile",
+        "emission_profile_share",
+        "scenario",
+        "year",
+        "reduction_targets_avg",
+        "sector_profile",
+        "sector_profile_share",
+        "benchmark_tr_score_avg",
+        "avg_transition_risk_equal_weight",
+        "avg_transition_risk_best_case",
+        "avg_transition_risk_worst_case",
+        "postcode",
+        "address",
+        "main_activity",
+        "min_headcount",
+        "max_headcount"
+      )
+  }
+}

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -92,7 +92,11 @@ transition_risk_profile <- function(emissions_profile,
       pivot_wider = pivot_wider,
       include_co2 = option_output_co2_footprint()
     ) |>
-    best_case_worst_case_avg_profile_ranking()
+    best_case_worst_case_avg_profile_ranking() |>
+    relocate_transition_risk_profile_cols(
+      pivot_wider = pivot_wider,
+      include_co2 = option_output_co2_footprint()
+    )
 }
 
 transition_risk_profile_impl <- function(emissions_profile,


### PR DESCRIPTION
Relates to [issue](https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/189)

This PR adds new function `relocate_transition_risk_profile_cols()` to relocate the transition risk profile columns as given in this [excel sheet](https://docs.google.com/spreadsheets/d/1e5QUcHBb6m9AcgHEK59RrFaTC69-MZ-t/edit?gid=424568592#gid=424568592).


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [x] Document user-facing changes in the changelog.
