### PR TITLE
Make `equal_weight` consistent with `best_case` and `worst_case` by not considering NAs

### DIFF
--- a/R/best_case_worst_case_impl.R
+++ b/R/best_case_worst_case_impl.R
@@ -1,6 +1,6 @@
 best_case_worst_case_impl <- function(data, col_risk, col_group_by) {
   data |>
-    compute_n_distinct_products() |>
+    compute_n_distinct_products(col_risk, col_group_by) |>
     compute_equal_weight() |>
     compute_min_risk_category_per_company_benchmark(col_risk, col_group_by) |>
     compute_max_risk_category_per_company_benchmark(col_risk, col_group_by) |>

--- a/R/utils-best_case_worst_case.R
+++ b/R/utils-best_case_worst_case.R
@@ -14,11 +14,12 @@ get_case_if_risk_counts_has_no_zero <- function(data, risk, count_risk_cases_per
   )
 }
 
-compute_n_distinct_products <- function(data) {
-  mutate(data,
-    n_distinct_products = n_distinct(.data[[col_europages_product()]], na.rm = TRUE),
-    .by = col_companies_id()
-  )
+compute_n_distinct_products <- function(data, col_risk, col_group_by) {
+  data |>
+    mutate(
+      n_distinct_products = n_distinct(.data[[col_europages_product()]][!is.na(.data[[col_risk]])], na.rm = TRUE),
+      .by = all_of(c(col_companies_id(), col_group_by))
+    )
 }
 
 compute_equal_weight <- function(data) {

--- a/tests/testthat/test-best_case_worst_case_emission_profile.R
+++ b/tests/testthat/test-best_case_worst_case_emission_profile.R
@@ -86,3 +86,26 @@ test_that("gives `NA` in `best_case` and `worst_case` if count of best and worst
     expected_worst_case
   )
 })
+
+test_that("`equal_weight` does not count unmatched `ep_product` after grouping by `companies_id` and `benchmark`", {
+  example_data <- example_best_case_worst_case_emission_profile(
+    companies_id = c("any", "any", "any", "any", "any"),
+    ep_product = c("one", "two", "three", "four", "five"),
+    benchmark = c("all", "all", "all", "tilt_sector", NA_character_),
+    emission_profile = c("low", "medium", NA_character_, "low", NA_character_)
+  )
+
+  out <- best_case_worst_case_emission_profile(example_data)
+
+  out_all <- filter(out, benchmark == "all")
+  expected_equal_weight_all <- 0.5
+  expect_equal(unique(out_all$equal_weight), expected_equal_weight_all)
+
+  out_tilt_sec <- filter(out, benchmark == "tilt_sector")
+  expected_equal_weight_tilt_sec <- 1.0
+  expect_equal(unique(out_tilt_sec$equal_weight), expected_equal_weight_tilt_sec)
+
+  out_NA <- filter(out, is.na(benchmark))
+  expected_equal_weight_NA <- NA_real_
+  expect_equal(unique(out_NA$equal_weight), expected_equal_weight_NA)
+})

--- a/tests/testthat/test-best_case_worst_case_transition_risk_profile.R
+++ b/tests/testthat/test-best_case_worst_case_transition_risk_profile.R
@@ -86,3 +86,26 @@ test_that("gives `NA` in `best_case` and `worst_case` if count of best and worst
     expected_worst_case
   )
 })
+
+test_that("`equal_weight` does not count unmatched `ep_product` after grouping by `companies_id` and `benchmark_tr_score`", {
+  example_data <- example_best_case_worst_case_transition_risk_profile(
+    companies_id = c("any", "any", "any", "any", "any"),
+    ep_product = c("one", "two", "three", "four", "five"),
+    benchmark_tr_score = c("all", "all", "all", "tilt_sector", NA_character_),
+    transition_risk_category = c("low", "medium", NA_character_, "low", NA_character_)
+  )
+
+  out <- best_case_worst_case_transition_risk_profile(example_data)
+
+  out_all <- filter(out, benchmark_tr_score == "all")
+  expected_equal_weight_all <- 0.5
+  expect_equal(unique(out_all$equal_weight), expected_equal_weight_all)
+
+  out_tilt_sec <- filter(out, benchmark_tr_score == "tilt_sector")
+  expected_equal_weight_tilt_sec <- 1.0
+  expect_equal(unique(out_tilt_sec$equal_weight), expected_equal_weight_tilt_sec)
+
+  out_NA <- filter(out, is.na(benchmark_tr_score))
+  expected_equal_weight_NA <- NA_real_
+  expect_equal(unique(out_NA$equal_weight), expected_equal_weight_NA)
+})


### PR DESCRIPTION
closes #285 

Dear @AnneSchoenauer @Tilmon 

Here is the reprex to show that this PR covers all the cases outlined in the [comment](https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues/285#issuecomment-2225066904):

``` r
library(readr, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(tiltToyData, warn.conflicts = FALSE)
library(tiltTransitionRisk, warn.conflicts = FALSE)
devtools::load_all(".")
#> ℹ Loading tiltIndicatorAfter
options(width = 5000)

example_data <- example_best_case_worst_case_transition_risk_profile(
  companies_id = c("any", "any", "any", "any", "any", "any", "any"),
  ep_product = c("one", "two", "three", "one", "two", "three", "four"),
  benchmark_tr_score = c("all", "all", "all", "tilt_sector", "tilt_sector", "tilt_sector", NA_character_),
  transition_risk_category = c("low", "medium", "low", "low", "medium", NA_character_, NA_character_)
)

out <- best_case_worst_case_transition_risk_profile(example_data)
out
#> # A tibble: 7 × 14
#>   companies_id ep_product benchmark_tr_score transition_risk_category n_distinct_products equal_weight min_risk_category_per_company_benchmark max_risk_category_per_company_benchmark best_risk worst_risk count_best_case_products_per_company_benchmark count_worst_case_products_per_company_benchmark best_case worst_case
#>   <chr>        <chr>      <chr>              <chr>                                  <int>        <dbl> <chr>                                   <chr>                                       <dbl>      <dbl>                                          <dbl>                                           <dbl>     <dbl>      <dbl>
#> 1 any          one        all                low                                        3        0.333 low                                     medium                                          1          0                                              2                                               1       0.5          0
#> 2 any          two        all                medium                                     3        0.333 low                                     medium                                          0          1                                              2                                               1       0            1
#> 3 any          three      all                low                                        3        0.333 low                                     medium                                          1          0                                              2                                               1       0.5          0
#> 4 any          one        tilt_sector        low                                        2        0.5   low                                     medium                                          1          0                                              1                                               1       1            0
#> 5 any          two        tilt_sector        medium                                     2        0.5   low                                     medium                                          0          1                                              1                                               1       0            1
#> 6 any          three      tilt_sector        <NA>                                       2        0.5   low                                     medium                                          0          0                                              1                                               1       0            0
#> 7 any          four       <NA>               <NA>                                       0       NA     <NA>                                    <NA>                                            0          0                                              0                                               0      NA           NA
```

<sup>Created on 2024-07-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Please review and let mw know of any possible issue! Thanks! :)

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [x] Document user-facing changes in the changelog.
