### PR TITLE
Adds column `amount_of_distinct_products_matched` at product level for both emissions profile and transition risk profile 

### DIFF
--- a/R/best_case_worst_case_avg_profile_ranking.R
+++ b/R/best_case_worst_case_avg_profile_ranking.R
@@ -84,14 +84,14 @@ add_avg_profile_ranking_worst_case <- function(data) {
 
 prepare_for_join_at_company_level_profile_ranking <- function(data) {
   data |>
-    select(-c(
+    select(-all_of(c(
       col_emission_profile(),
       col_europages_product(),
       "avg_profile_ranking",
       "profile_ranking",
       "max_risk_category_per_company_benchmark",
       "min_risk_category_per_company_benchmark"
-    )) |>
+    ))) |>
     distinct()
 }
 

--- a/R/best_case_worst_case_avg_reduction_targets.R
+++ b/R/best_case_worst_case_avg_reduction_targets.R
@@ -88,7 +88,7 @@ add_avg_reduction_targets_worst_case <- function(data) {
 
 prepare_for_join_at_company_level_reduction_targets <- function(data) {
   data |>
-    select(-c(
+    select(-all_of(c(
       col_sector_profile(),
       col_europages_product(),
       "scenario_year",
@@ -96,7 +96,7 @@ prepare_for_join_at_company_level_reduction_targets <- function(data) {
       "reduction_targets",
       "max_risk_category_per_company_benchmark",
       "min_risk_category_per_company_benchmark"
-    )) |>
+    ))) |>
     distinct()
 }
 

--- a/R/best_case_worst_case_impl.R
+++ b/R/best_case_worst_case_impl.R
@@ -1,6 +1,7 @@
 best_case_worst_case_impl <- function(data, col_risk, col_group_by) {
   data |>
-    compute_n_distinct_products(col_risk, col_group_by) |>
+    compute_n_distinct_products() |>
+    compute_n_distinct_products_matched(col_risk, col_group_by) |>
     compute_equal_weight() |>
     compute_min_risk_category_per_company_benchmark(col_risk, col_group_by) |>
     compute_max_risk_category_per_company_benchmark(col_risk, col_group_by) |>

--- a/R/best_case_worst_case_transition_risk_profile_at_company_level.R
+++ b/R/best_case_worst_case_transition_risk_profile_at_company_level.R
@@ -99,14 +99,14 @@ prepare_avg_best_case_join_table_transition_risk <- function(data) {
 
 prepare_for_join_at_company_level_transition_risk <- function(data) {
   data |>
-    select(-c(
+    select(-all_of(c(
       col_transition_risk_category(),
       col_europages_product(),
       "avg_transition_risk",
       "transition_risk_score",
       "max_risk_category_per_company_benchmark",
       "min_risk_category_per_company_benchmark"
-    )) |>
+    ))) |>
     distinct()
 }
 
@@ -124,11 +124,11 @@ add_avg_col <- function(data,
       NA_real_,
       mean(.data[[col]], na.rm = TRUE)
     ),
-    .by = c(
+    .by = all_of(c(
       col_companies_id(),
       group_by,
       risk_category
-    )
+    ))
   )
 }
 
@@ -149,6 +149,6 @@ add_avg_case_col_if_risk_category_match <- function(data,
 
 prepare_avg_best_case_join_table <- function(data, case1_col, case2_col) {
   data |>
-    select(-c(case1_col)) |>
+    select(-all_of(c(case1_col))) |>
     filter(!is.na(.data[[case2_col]]))
 }

--- a/R/pivot_wider_transition_risk_profile.R
+++ b/R/pivot_wider_transition_risk_profile.R
@@ -189,11 +189,11 @@ select_subset_emissions_profile_id_cols <- function(data, include_co2 = FALSE) {
 }
 
 select_emissions_profile_pivot_cols <- function(data, include_co2 = FALSE) {
-  select(data, c(
+  select(data, all_of(c(
     select_subset_emissions_profile_id_cols(include_co2 = include_co2),
     "emission_profile",
     "emission_profile_share"
-  ))
+  )))
 }
 
 select_subset_sector_profile_id_cols <- function(data) {
@@ -208,11 +208,11 @@ select_subset_sector_profile_id_cols <- function(data) {
 }
 
 select_sector_profile_pivot_cols <- function(data) {
-  select(data, c(
+  select(data, all_of(c(
     select_subset_sector_profile_id_cols(),
     "sector_profile",
     "sector_profile_share"
-  ))
+  )))
 }
 
 select_subset_transition_risk_profile_id_cols <- function(data) {
@@ -228,9 +228,9 @@ select_subset_transition_risk_profile_id_cols <- function(data) {
 }
 
 select_transition_risk_profile_pivot_cols <- function(data) {
-  select(data, c(
+  select(data, all_of(c(
     select_subset_transition_risk_profile_id_cols(),
     "transition_risk_category",
     "transition_risk_category_share"
-  ))
+  )))
 }

--- a/R/polish_best_case_worst_case.R
+++ b/R/polish_best_case_worst_case.R
@@ -1,14 +1,15 @@
 polish_best_case_worst_case <- function(data) {
   data |>
-    select(-c(
+    select(-all_of(c(
       "min_risk_category_per_company_benchmark",
       "max_risk_category_per_company_benchmark",
       "best_risk",
       "worst_risk",
       "count_best_case_products_per_company_benchmark",
       "count_worst_case_products_per_company_benchmark"
-    )) |>
-    rename(amount_of_distinct_products = "n_distinct_products") |>
+    ))) |>
+    rename(amount_of_distinct_products = "n_distinct_products",
+           amount_of_distinct_products_matched = "n_distinct_products_matched") |>
     distinct()
 }
 

--- a/R/relocate_transition_risk_profile_cols.R
+++ b/R/relocate_transition_risk_profile_cols.R
@@ -59,6 +59,7 @@ relocate_transition_risk_profile_cols_at_product_level <- function(
       "transition_risk_profile_best_case",
       "transition_risk_profile_worst_case",
       "amount_of_distinct_products",
+      "amount_of_distinct_products_matched",
       "min_headcount",
       "max_headcount"
     )

--- a/R/score_transition_risk.R
+++ b/R/score_transition_risk.R
@@ -70,7 +70,7 @@ score_transition_risk <-
       full_join_emmissions_sector(trs_emissions, trs_sector) |>
       create_tr_benchmarks_tr_score() |>
       limit_transition_risk_score_between_0_and_1() |>
-      select(-c("scenario_year", "benchmark")) |>
+      select(-all_of(c("scenario_year", "benchmark"))) |>
       left_join(
         union_emissions_sector_rows,
         by = c("companies_id", "ep_product", "activity_uuid_product_uuid"),

--- a/R/score_transition_risk_and_polish.R
+++ b/R/score_transition_risk_and_polish.R
@@ -145,7 +145,8 @@ score_transition_risk_and_polish <- function(emissions_profile,
     )) |>
     left_join(
       select_transition_risk_score_product,
-      by = c("companies_id", "ep_product", "benchmark_tr_score")
+      by = c("companies_id", "ep_product", "benchmark_tr_score"),
+      relationship = "many-to-many"
     ) |>
     distinct()
 
@@ -212,5 +213,5 @@ coalesce_common_col <- function(data, col, suffix1, suffix2) {
   col_suffix2 = paste(col, suffix2, sep = ".")
   data |>
     mutate({{ col }} := coalesce(.data[[col_suffix1]], .data[[col_suffix2]])) |>
-    select(-c(col_suffix1, col_suffix2))
+    select(-all_of(c(col_suffix1, col_suffix2)))
 }

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -125,24 +125,13 @@ transition_risk_profile_impl <- function(emissions_profile,
     add_transition_risk_category() |>
     best_case_worst_case_transition_risk_profile() |>
     polish_best_case_worst_case() |>
-    polish_best_case_worst_case_transition_risk_profile() |>
-    polish_transition_risk_at_product_level()
+    polish_best_case_worst_case_transition_risk_profile()
 
   company <- transition_risk_scores |>
     unnest_company() |>
     polish_transition_risk_at_company_level()
 
   tilt_profile(nest_levels(product, company))
-}
-
-polish_transition_risk_at_product_level <- function(data) {
-  data |>
-    relocate(c(
-      "activity_uuid_product_uuid", "transition_risk_score",
-      "transition_risk_low_threshold", "transition_risk_high_threshold",
-      "transition_risk_category", "benchmark_tr_score", "profile_ranking",
-      "reduction_targets"
-    ))
 }
 
 polish_transition_risk_at_company_level <- function(data) {

--- a/R/utils-best_case_worst_case.R
+++ b/R/utils-best_case_worst_case.R
@@ -14,18 +14,26 @@ get_case_if_risk_counts_has_no_zero <- function(data, risk, count_risk_cases_per
   )
 }
 
-compute_n_distinct_products <- function(data, col_risk, col_group_by) {
+compute_n_distinct_products <- function(data) {
   data |>
     mutate(
-      n_distinct_products = n_distinct(.data[[col_europages_product()]][!is.na(.data[[col_risk]])], na.rm = TRUE),
+      n_distinct_products = n_distinct(.data[[col_europages_product()]], na.rm = TRUE),
+      .by = col_companies_id()
+    )
+}
+
+compute_n_distinct_products_matched <- function(data, col_risk, col_group_by) {
+  data |>
+    mutate(
+      n_distinct_products_matched = n_distinct(.data[[col_europages_product()]][!is.na(.data[[col_risk]])], na.rm = TRUE),
       .by = all_of(c(col_companies_id(), col_group_by))
     )
 }
 
 compute_equal_weight <- function(data) {
   mutate(data,
-    equal_weight = ifelse(.data$n_distinct_products == 0, NA,
-      1 / .data$n_distinct_products
+    equal_weight = ifelse(.data$n_distinct_products_matched == 0, NA,
+      1 / .data$n_distinct_products_matched
     )
   )
 }

--- a/tests/testthat/_snaps/profile_emissions.md
+++ b/tests/testthat/_snaps/profile_emissions.md
@@ -3,22 +3,22 @@
     Code
       names(unnest_product(out))
     Output
-       [1] "companies_id"                       "company_name"                      
-       [3] "country"                            "emission_profile"                  
-       [5] "benchmark"                          "ep_product"                        
-       [7] "matched_activity_name"              "matched_reference_product"         
-       [9] "unit"                               "multi_match"                       
-      [11] "matching_certainty"                 "matching_certainty_company_average"
-      [13] "tilt_sector"                        "tilt_subsector"                    
-      [15] "isic_4digit"                        "isic_4digit_name"                  
-      [17] "company_city"                       "postcode"                          
-      [19] "address"                            "main_activity"                     
-      [21] "activity_uuid_product_uuid"         "profile_ranking"                   
-      [23] "min_headcount"                      "max_headcount"                     
-      [25] "ei_geography"                       "co2e_lower"                        
-      [27] "co2e_upper"                         "amount_of_distinct_products"       
-      [29] "emissions_profile_equal_weight"     "emissions_profile_best_case"       
-      [31] "emissions_profile_worst_case"      
+       [1] "companies_id"                        "company_name"                       
+       [3] "country"                             "emission_profile"                   
+       [5] "benchmark"                           "ep_product"                         
+       [7] "matched_activity_name"               "matched_reference_product"          
+       [9] "unit"                                "multi_match"                        
+      [11] "matching_certainty"                  "matching_certainty_company_average" 
+      [13] "tilt_sector"                         "tilt_subsector"                     
+      [15] "isic_4digit"                         "isic_4digit_name"                   
+      [17] "company_city"                        "postcode"                           
+      [19] "address"                             "main_activity"                      
+      [21] "activity_uuid_product_uuid"          "profile_ranking"                    
+      [23] "min_headcount"                       "max_headcount"                      
+      [25] "ei_geography"                        "co2e_lower"                         
+      [27] "co2e_upper"                          "amount_of_distinct_products"        
+      [29] "amount_of_distinct_products_matched" "emissions_profile_equal_weight"     
+      [31] "emissions_profile_best_case"         "emissions_profile_worst_case"       
 
 ---
 

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -551,6 +551,7 @@ test_that("the output at product level has all the new required columns (#189)",
   expect_true(any(matches_name(product, "matching_certainty")))
   expect_true(any(matches_name(product, "company_name")))
   expect_true(any(matches_name(product, "emissions_profile_equal_weight")))
+  expect_true(any(matches_name(product, "amount_of_distinct_products_matched")))
 })
 
 test_that("the output at company level has has all the new required columns (#189, #290)", {


### PR DESCRIPTION
Dear @Tilmon,

This PR adds the `amount_of_distinct_products_matched` column at product level for both emissions profile and transition risk profile to better understand the updated `equal_weight` column which uses `amount_of_distinct_products_matched` instead of `amount_of_distinct_products` (old input).

This PR also removes warnings after including `all_of()` function.


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
