### PR TITLE
Create `add_transition_risk_NA_share()` function for transition risk profile indicator

### DIFF
--- a/R/add_transition_risk_NA_share.R
+++ b/R/add_transition_risk_NA_share.R
@@ -13,10 +13,10 @@ add_transition_risk_NA_share <- function(data) {
 add_transition_risk_NA_share_at_product_level <- function(data) {
   data |>
     fill_benchmark_tr_score() |>
-    compute_transition_risk_NA_amount_all() |>
-    compute_transition_risk_NA_amount_benchmarks() |>
-    compute_transition_risk_NA_total() |>
-    compute_transition_risk_NA_share() |>
+    transition_risk_NA_amount_all() |>
+    transition_risk_NA_amount_benchmarks() |>
+    transition_risk_NA_total() |>
+    transition_risk_NA_share() |>
     polish_transition_risk_NA_share()
 }
 
@@ -50,7 +50,7 @@ fill_benchmark_tr_score <- function(data) {
   ))
 }
 
-compute_transition_risk_NA_amount_all <- function(data) {
+transition_risk_NA_amount_all <- function(data) {
   mutate(data,
     transition_risk_NA_amount_all = n_distinct(
       .data[[col_europages_product()]][is.na(.data$matched_activity_name) | is.na(.data$reduction_targets)]
@@ -59,7 +59,7 @@ compute_transition_risk_NA_amount_all <- function(data) {
   )
 }
 
-compute_transition_risk_NA_amount_benchmarks <- function(data) {
+transition_risk_NA_amount_benchmarks <- function(data) {
   mutate(data,
     transition_risk_NA_amount_benchmarks = n_distinct(
       .data[[col_europages_product()]][is.na(.data$transition_risk_score)]
@@ -68,7 +68,7 @@ compute_transition_risk_NA_amount_benchmarks <- function(data) {
   )
 }
 
-compute_transition_risk_NA_total <- function(data) {
+transition_risk_NA_total <- function(data) {
   mutate(data,
     transition_risk_NA_total = ifelse(
       is.na(.data$matched_activity_name) | is.na(.data$reduction_targets),
@@ -79,7 +79,7 @@ compute_transition_risk_NA_total <- function(data) {
   )
 }
 
-compute_transition_risk_NA_share <- function(data) {
+transition_risk_NA_share <- function(data) {
   mutate(data,
     transition_risk_NA_share = ifelse(
       .data$amount_of_distinct_products == 0,

--- a/R/add_transition_risk_NA_share.R
+++ b/R/add_transition_risk_NA_share.R
@@ -1,0 +1,98 @@
+add_transition_risk_NA_share <- function(data) {
+  product <- data |>
+    unnest_product() |>
+    add_transition_risk_NA_share_at_product_level()
+
+  company <- data |>
+    unnest_company() |>
+    select_and_join_transition_risk_NA_share_at_company_level(product)
+
+  tilt_profile(nest_levels(product, company))
+}
+
+add_transition_risk_NA_share_at_product_level <- function(data) {
+  data |>
+    fill_benchmark_tr_score() |>
+    compute_transition_risk_NA_amount_all() |>
+    compute_transition_risk_NA_amount_benchmarks() |>
+    compute_transition_risk_NA_total() |>
+    compute_transition_risk_NA_share() |>
+    polish_transition_risk_NA_share()
+}
+
+select_and_join_transition_risk_NA_share_at_company_level <- function(data, product) {
+  join_table <- product |>
+    select(all_of(c(
+      "companies_id",
+      "benchmark_tr_score",
+      "transition_risk_NA_share"
+    ))) |>
+    distinct()
+
+  data |>
+    left_join(
+      join_table,
+      by = all_of(c("companies_id",
+        "benchmark_tr_score_avg" = "benchmark_tr_score"
+      ))
+    )
+}
+
+fill_benchmark_tr_score <- function(data) {
+  mutate(data, benchmark_tr_score = ifelse(
+    is.na(.data[[col_transition_risk_grouped_by()]]),
+    paste(.data[[col_scenario()]],
+      .data[[col_year()]],
+      .data[[col_emission_grouped_by()]],
+      sep = "_"
+    ),
+    .data[[col_transition_risk_grouped_by()]]
+  ))
+}
+
+compute_transition_risk_NA_amount_all <- function(data) {
+  mutate(data,
+    transition_risk_NA_amount_all = n_distinct(
+      .data[[col_europages_product()]][is.na(.data$matched_activity_name) | is.na(.data$reduction_targets)]
+    ),
+    .by = col_companies_id()
+  )
+}
+
+compute_transition_risk_NA_amount_benchmarks <- function(data) {
+  mutate(data,
+    transition_risk_NA_amount_benchmarks = n_distinct(
+      .data[[col_europages_product()]][is.na(.data$transition_risk_score)]
+    ),
+    .by = all_of(c(col_companies_id(), col_transition_risk_grouped_by()))
+  )
+}
+
+compute_transition_risk_NA_total <- function(data) {
+  mutate(data,
+    transition_risk_NA_total = ifelse(
+      is.na(.data$matched_activity_name) | is.na(.data$reduction_targets),
+      .data$transition_risk_NA_amount_all,
+      .data$transition_risk_NA_amount_all + .data$transition_risk_NA_amount_benchmarks
+    ),
+    .by = all_of(c(col_companies_id(), col_transition_risk_grouped_by()))
+  )
+}
+
+compute_transition_risk_NA_share <- function(data) {
+  mutate(data,
+    transition_risk_NA_share = ifelse(
+      .data$amount_of_distinct_products == 0,
+      NA,
+      .data$transition_risk_NA_total / .data$amount_of_distinct_products
+    ),
+    .by = all_of(c(col_companies_id(), col_transition_risk_grouped_by()))
+  )
+}
+
+polish_transition_risk_NA_share <- function(data) {
+  select(data, -all_of(c(
+    "transition_risk_NA_amount_all",
+    "transition_risk_NA_amount_benchmarks"
+  )))
+}

--- a/R/relocate_transition_risk_profile_cols.R
+++ b/R/relocate_transition_risk_profile_cols.R
@@ -60,6 +60,8 @@ relocate_transition_risk_profile_cols_at_product_level <- function(
       "transition_risk_profile_worst_case",
       "amount_of_distinct_products",
       "amount_of_distinct_products_matched",
+      "transition_risk_NA_total",
+      "transition_risk_NA_share",
       "min_headcount",
       "max_headcount"
     )
@@ -97,6 +99,7 @@ relocate_transition_risk_profile_cols_at_company_level <- function(
         "avg_transition_risk_equal_weight",
         "avg_transition_risk_best_case",
         "avg_transition_risk_worst_case",
+        "transition_risk_NA_share",
         "postcode",
         "address",
         "main_activity",
@@ -127,6 +130,7 @@ relocate_transition_risk_profile_cols_at_company_level <- function(
         "avg_transition_risk_equal_weight",
         "avg_transition_risk_best_case",
         "avg_transition_risk_worst_case",
+        "transition_risk_NA_share",
         "postcode",
         "address",
         "main_activity",

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -94,6 +94,7 @@ transition_risk_profile <- function(emissions_profile,
     ) |>
     best_case_worst_case_avg_profile_ranking() |>
     best_case_worst_case_avg_reduction_targets() |>
+    add_transition_risk_NA_share() |>
     relocate_transition_risk_profile_cols(
       pivot_wider = pivot_wider,
       include_co2 = option_output_co2_footprint()


### PR DESCRIPTION
closes #289

Dear @maurolepore,

This PR creates the `add_transition_risk_NA_share()` function to add column `transition_risk_NA_share` at product and company level for transition risk profile. It also adds `transition_risk_NA_total` column at product level.

Theoretical review is already done by @Tilmon using real data. Hence, @maurolepore I would like your technical review on this PR. Thanks!

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
