### PR TITLE
Assign NA to `coefficient_of_variation` if mean is zero

### DIFF
--- a/R/coefficient_of_variation_transition_risk_profile.R
+++ b/R/coefficient_of_variation_transition_risk_profile.R
@@ -100,7 +100,7 @@ add_coefficient_of_variation <- function(data, cov_col, sd_col, mean_col) {
     data,
     {{ cov_col }} := case_when(
       is.na(.data[[mean_col]]) ~ NA_real_,
-      .data[[mean_col]] == 0.0 ~ 0.0,
+      .data[[mean_col]] == 0.0 ~ NA_real_,
       TRUE ~ (.data[[sd_col]] / .data[[mean_col]]) * 100
     )
   )

--- a/tests/testthat/test-coefficient_of_variation.R
+++ b/tests/testthat/test-coefficient_of_variation.R
@@ -52,7 +52,7 @@ test_that("`add_coefficient_of_variation_sector_target()` outputs correct `cov_s
   expect_true(is.na(check_na$cov_sector_target))
 })
 
-test_that("`add_coefficient_of_variation_sector_target()` outputs zero `cov_sector_target` for zero mean", {
+test_that("`add_coefficient_of_variation_sector_target()` outputs NA `cov_sector_target` for zero mean", {
   sector_target_input <- tibble(
     reduction_targets_avg = -1,
     avg_reduction_targets_best_case = 1,
@@ -60,11 +60,10 @@ test_that("`add_coefficient_of_variation_sector_target()` outputs zero `cov_sect
   )
   out <- add_coefficient_of_variation_sector_target(sector_target_input)
 
-  expected_coefficient_of_variation <- 0.0
-  expect_true(out$cov_sector_target == expected_coefficient_of_variation)
+  expect_true(is.na(out$cov_sector_target))
 })
 
-test_that("`add_coefficient_of_variation_emission_rank()` outputs zero `cov_emission_rank` for zero mean", {
+test_that("`add_coefficient_of_variation_emission_rank()` outputs NA `cov_emission_rank` for zero mean", {
   emission_rank_input <- tibble(
     profile_ranking_avg = -1,
     avg_profile_ranking_best_case = 1,
@@ -72,11 +71,10 @@ test_that("`add_coefficient_of_variation_emission_rank()` outputs zero `cov_emis
   )
   out <- add_coefficient_of_variation_emission_rank(emission_rank_input)
 
-  expected_coefficient_of_variation <- 0
-  expect_true(out$cov_emission_rank == expected_coefficient_of_variation)
+  expect_true(is.na(out$cov_emission_rank))
 })
 
-test_that("`add_coefficient_of_variation_transition_risk()` outputs zero `cov_transition_risk` for zero mean", {
+test_that("`add_coefficient_of_variation_transition_risk()` outputs NA `cov_transition_risk` for zero mean", {
   transition_risk_input <- tibble(
     avg_transition_risk_equal_weight = -1,
     avg_transition_risk_best_case = 1,
@@ -84,6 +82,5 @@ test_that("`add_coefficient_of_variation_transition_risk()` outputs zero `cov_tr
   )
   out <- add_coefficient_of_variation_transition_risk(transition_risk_input)
 
-  expected_coefficient_of_variation <- 0
-  expect_true(out$cov_transition_risk == expected_coefficient_of_variation)
+  expect_true(is.na(out$cov_transition_risk))
 })


### PR DESCRIPTION
closes #304

This PR fixes the coefficient of variation by assigning NA to it if the mean is zero too ([issue](https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues/304)). As you can see from the below reprex, the `cov_sector_target` is NA if `mean_sector_target` is zero.

``` r
library(tibble, warn.conflicts = FALSE)
devtools::load_all(".")
#> ℹ Loading tiltIndicatorAfter
options(width = 5000)

sector_target_input <- tibble(
  reduction_targets_avg = -1,
  avg_reduction_targets_best_case = 1,
  avg_reduction_targets_worst_case = 0
)
out <- tiltIndicatorAfter:::add_coefficient_of_variation_sector_target(sector_target_input)
out
#> # A tibble: 1 × 6
#>   reduction_targets_avg avg_reduction_targets_best_case avg_reduction_targets_worst_case mean_sector_target standard_deviation_sector_target cov_sector_target
#>                   <dbl>                           <dbl>                            <dbl>              <dbl>                            <dbl>             <dbl>
#> 1                    -1                               1                                0                  0                            0.816                NA
```

<sup>Created on 2024-08-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [x] Document user-facing changes in the changelog.
