### PR TITLE
Remove case 3 companies for the base output and co2 columns for the webtool output

### DIFF
--- a/R/prepare_webtool_output.R
+++ b/R/prepare_webtool_output.R
@@ -1,13 +1,16 @@
-prepare_webtool_output <- function(data, pivot_wider = FALSE, for_webtool = FALSE) {
+prepare_webtool_output <- function(data,
+                                   pivot_wider = FALSE,
+                                   for_webtool = FALSE,
+                                   include_co2 = FALSE) {
   if (pivot_wider & for_webtool) {
-    prepare_webtool_output_impl(data)
+    prepare_webtool_output_impl(data, include_co2 = include_co2)
   }
   else {
     data
   }
 }
 
-prepare_webtool_output_impl <- function(data) {
+prepare_webtool_output_impl <- function(data, include_co2 = FALSE) {
   product <- data |>
     unnest_product() |>
     select_webtool_cols_at_product_level()
@@ -16,6 +19,14 @@ prepare_webtool_output_impl <- function(data) {
     unnest_company() |>
     select_webtool_cols_at_company_level_wide() |>
     rename_webtool_cols_at_company_level_wide()
+
+  if (include_co2) {
+    product <- product |>
+      select(-all_of(c("co2_footprint")))
+
+    company <- company |>
+      select(-all_of(c("co2e_avg")))
+  }
 
   tilt_profile(nest_levels(product, company))
 }


### PR DESCRIPTION
* closes https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/197
* Relates to https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/209

This PR removes the Case 3 companies followed by this [comment](https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/169#issuecomment-2284344632) from the base output of `tiltIndicatorAfter`. It also removes the `co2_footprint` column at product level and `co2e_avg` column at company level for webtool output.


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
