### PR TITLE
Remove long format option for company level columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/prepare_webtool_output.R
+++ b/R/prepare_webtool_output.R
@@ -1,8 +1,7 @@
 prepare_webtool_output <- function(data,
-                                   pivot_wider = FALSE,
                                    for_webtool = FALSE,
                                    include_co2 = FALSE) {
-  if (pivot_wider & for_webtool) {
+  if (for_webtool) {
     prepare_webtool_output_impl(data, include_co2 = include_co2)
   }
   else {

--- a/R/relocate_transition_risk_profile_cols.R
+++ b/R/relocate_transition_risk_profile_cols.R
@@ -1,7 +1,6 @@
 relocate_transition_risk_profile_cols <- function(
     data,
-    include_co2 = FALSE,
-    pivot_wider = FALSE) {
+    include_co2 = FALSE) {
   product <- data |>
     unnest_product() |>
     relocate_transition_risk_profile_cols_at_product_level(
@@ -11,8 +10,7 @@ relocate_transition_risk_profile_cols <- function(
   company <- data |>
     unnest_company() |>
     relocate_transition_risk_profile_cols_at_company_level(
-      include_co2 = include_co2,
-      pivot_wider = pivot_wider
+      include_co2 = include_co2
     )
 
   tilt_profile(nest_levels(product, company))
@@ -69,73 +67,39 @@ relocate_transition_risk_profile_cols_at_product_level <- function(
 
 relocate_transition_risk_profile_cols_at_company_level <- function(
     data,
-    pivot_wider = FALSE,
     include_co2 = FALSE) {
-  if (pivot_wider) {
-    data |>
-      relocate(
-        "companies_id",
-        "company_name",
-        "country",
-        if (include_co2) "co2_avg",
-        "benchmark",
-        "profile_ranking_avg",
-        "avg_profile_ranking_best_case",
-        "avg_profile_ranking_worst_case",
-        "emission_category_low",
-        "emission_category_medium",
-        "emission_category_high",
-        "emission_category_NA",
-        "scenario",
-        "year",
-        "reduction_targets_avg",
-        "avg_reduction_targets_best_case",
-        "avg_reduction_targets_worst_case",
-        "sector_category_low",
-        "sector_category_medium",
-        "sector_category_high",
-        "sector_category_NA",
-        "benchmark_tr_score_avg",
-        "avg_transition_risk_equal_weight",
-        "avg_transition_risk_best_case",
-        "avg_transition_risk_worst_case",
-        "transition_risk_NA_share",
-        "postcode",
-        "address",
-        "main_activity",
-        "min_headcount",
-        "max_headcount"
-      )
-  } else {
-    data |>
-      relocate(
-        "companies_id",
-        "company_name",
-        "country",
-        if (include_co2) "co2_avg",
-        "benchmark",
-        "profile_ranking_avg",
-        "avg_profile_ranking_best_case",
-        "avg_profile_ranking_worst_case",
-        "emission_profile",
-        "emission_profile_share",
-        "scenario",
-        "year",
-        "reduction_targets_avg",
-        "avg_reduction_targets_best_case",
-        "avg_reduction_targets_worst_case",
-        "sector_profile",
-        "sector_profile_share",
-        "benchmark_tr_score_avg",
-        "avg_transition_risk_equal_weight",
-        "avg_transition_risk_best_case",
-        "avg_transition_risk_worst_case",
-        "transition_risk_NA_share",
-        "postcode",
-        "address",
-        "main_activity",
-        "min_headcount",
-        "max_headcount"
-      )
-  }
+  data |>
+    relocate(
+      "companies_id",
+      "company_name",
+      "country",
+      if (include_co2) "co2_avg",
+      "benchmark",
+      "profile_ranking_avg",
+      "avg_profile_ranking_best_case",
+      "avg_profile_ranking_worst_case",
+      "emission_category_low",
+      "emission_category_medium",
+      "emission_category_high",
+      "emission_category_NA",
+      "scenario",
+      "year",
+      "reduction_targets_avg",
+      "avg_reduction_targets_best_case",
+      "avg_reduction_targets_worst_case",
+      "sector_category_low",
+      "sector_category_medium",
+      "sector_category_high",
+      "sector_category_NA",
+      "benchmark_tr_score_avg",
+      "avg_transition_risk_equal_weight",
+      "avg_transition_risk_best_case",
+      "avg_transition_risk_worst_case",
+      "transition_risk_NA_share",
+      "postcode",
+      "address",
+      "main_activity",
+      "min_headcount",
+      "max_headcount"
+    )
 }

--- a/R/transition_risk_profile.R
+++ b/R/transition_risk_profile.R
@@ -6,8 +6,6 @@
 #' @param emissions_profile Nested data frame. The output of
 #'   `profile_emissions()`.
 #' @param sector_profile Nested data frame. The output of `profile_sector()`.
-#' @param pivot_wider Logical. Pivot the output at company level to a wide
-#'   format?
 #' @param co2 A dataframe
 #' @param all_activities_scenario_sectors A dataframe
 #' @param scenarios A dataframe
@@ -68,7 +66,6 @@
 #'   co2 = toy_emissions_profile_products_ecoinvent,
 #'   all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
 #'   scenarios = toy_sector_profile_any_scenarios,
-#'   pivot_wider = FALSE,
 #'   for_webtool = FALSE
 #' )
 #'
@@ -80,7 +77,6 @@ transition_risk_profile <- function(emissions_profile,
                                     co2,
                                     all_activities_scenario_sectors,
                                     scenarios,
-                                    pivot_wider = FALSE,
                                     for_webtool = FALSE) {
   transition_risk_profile_impl(
     emissions_profile,
@@ -92,20 +88,17 @@ transition_risk_profile <- function(emissions_profile,
     add_transition_risk_category_at_company_level() |>
     best_case_worst_case_transition_risk_profile_at_company_level() |>
     pivot_wider_transition_risk_profile(
-      pivot_wider = pivot_wider,
       include_co2 = option_output_co2_footprint()
     ) |>
     best_case_worst_case_avg_profile_ranking() |>
     best_case_worst_case_avg_reduction_targets() |>
     add_transition_risk_NA_share() |>
     relocate_transition_risk_profile_cols(
-      pivot_wider = pivot_wider,
       include_co2 = option_output_co2_footprint()
     ) |>
     coefficient_of_variation_transition_risk_profile() |>
     polish_transition_risk_profile() |>
     prepare_webtool_output(
-      pivot_wider = pivot_wider,
       for_webtool = for_webtool,
       include_co2 = option_output_co2_footprint()
     ) |>

--- a/man/pivot_wider_transition_risk_profile.Rd
+++ b/man/pivot_wider_transition_risk_profile.Rd
@@ -2,25 +2,18 @@
 % Please edit documentation in R/pivot_wider_transition_risk_profile.R
 \name{pivot_wider_transition_risk_profile}
 \alias{pivot_wider_transition_risk_profile}
-\title{Calculate the indicator "transition risk profile"}
+\title{Pivot company-level columns to wide format for indicator "transition risk profile"}
 \usage{
-pivot_wider_transition_risk_profile(
-  data,
-  pivot_wider = FALSE,
-  include_co2 = FALSE
-)
+pivot_wider_transition_risk_profile(data, include_co2 = FALSE)
 }
 \arguments{
-\item{pivot_wider}{Logical. Pivot the output at company level to a wide
-format?}
-
 \item{include_co2}{Logical. Include \verb{co2_*} columns ?}
 }
 \value{
 A data frame with the column \code{companies_id}, and the list columns \code{product} and \code{company} holding the outputs at product and company level.
 }
 \description{
-Calculate the indicator "transition risk profile"
+Pivot company-level columns to wide format for indicator "transition risk profile"
 }
 \examples{
 \dontrun{
@@ -63,45 +56,18 @@ toy_sector_profile <- profile_sector(
   isic = toy_isic_name
 )
 
-# Most banks need company-level results in long format
-pivot_wider <- FALSE
-
-long <- transition_risk_profile_impl(
+wide_format <- transition_risk_profile_impl(
   emissions_profile,
   sector_profile,
   co2,
   all_activities_scenario_sectors,
-  scenarios,
-  exclude_co2 = pivot_wider
+  scenarios
 ) |>
   add_transition_risk_category_at_company_level() |>
   best_case_worst_case_transition_risk_profile_at_company_level() |>
-  pivot_wider_transition_risk_profile(
-    pivot_wider = pivot_wider,
-    include_co2 = TRUE
-  ) |>
+  pivot_wider_transition_risk_profile(include_co2 = TRUE) |>
   unnest_company()
-long
-
-# Some banks need company-level results in wide format
-pivot_wider <- TRUE
-
-wide <- transition_risk_profile_impl(
-  emissions_profile,
-  sector_profile,
-  co2,
-  all_activities_scenario_sectors,
-  scenarios,
-  exclude_co2 = pivot_wider
-) |>
-  add_transition_risk_category_at_company_level() |>
-  best_case_worst_case_transition_risk_profile_at_company_level() |>
-  pivot_wider_transition_risk_profile(
-    pivot_wider = pivot_wider,
-    include_co2 = TRUE
-  ) |>
-  unnest_company()
-wide
+wide_format
 
 # Cleanup
 options(restore)

--- a/man/tiltIndicatorAfter-package.Rd
+++ b/man/tiltIndicatorAfter-package.Rd
@@ -20,9 +20,17 @@ Useful links:
 \author{
 \strong{Maintainer}: Kalash Singhal \email{kalash@2degrees-investing.org}
 
+Authors:
+\itemize{
+  \item Mauro Lepore \email{maurolepore@gmail.com} (\href{https://orcid.org/0000-0002-1986-7988}{ORCID})
+  \item Anne Schoenauer \email{anne.schoenauer@2degrees-investing.org} (\href{https://orcid.org/0000-0002-4576-8799}{ORCID})
+  \item Tilman Trompke \email{tilman@2degrees-investing.org} (\href{https://orcid.org/0009-0003-3351-5131}{ORCID})
+  \item Linda Delacombaz \email{linda@2degrees-investing.org}
+}
+
 Other contributors:
 \itemize{
-  \item Mauro Lepore (\href{https://orcid.org/0000-0002-1986-7988}{ORCID}) [contributor]
+  \item 2 Degrees Investing Initiative \email{contact@2degrees-investing.org} [copyright holder, funder]
 }
 
 }

--- a/man/transition_risk_profile.Rd
+++ b/man/transition_risk_profile.Rd
@@ -10,7 +10,6 @@ transition_risk_profile(
   co2,
   all_activities_scenario_sectors,
   scenarios,
-  pivot_wider = FALSE,
   for_webtool = FALSE
 )
 }
@@ -25,9 +24,6 @@ transition_risk_profile(
 \item{all_activities_scenario_sectors}{A dataframe}
 
 \item{scenarios}{A dataframe}
-
-\item{pivot_wider}{Logical. Pivot the output at company level to a wide
-format?}
 
 \item{for_webtool}{Logical. Is it output for webtool or not?}
 }
@@ -87,7 +83,6 @@ output <- transition_risk_profile(
   co2 = toy_emissions_profile_products_ecoinvent,
   all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
   scenarios = toy_sector_profile_any_scenarios,
-  pivot_wider = FALSE,
   for_webtool = FALSE
 )
 

--- a/tests/testthat/test-transition_risk_profile.R
+++ b/tests/testthat/test-transition_risk_profile.R
@@ -36,8 +36,7 @@ test_that("yields a 'tilt_profile'", {
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
+    scenarios = toy_sector_profile_any_scenarios
   )
 
   expect_s3_class(output, "tilt_profile")
@@ -82,8 +81,7 @@ test_that("outputs `NA` transition risk category for `NA` transition risk score 
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
+    scenarios = toy_sector_profile_any_scenarios
   ) |>
     unnest_product() |>
     filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
@@ -92,53 +90,6 @@ test_that("outputs `NA` transition risk category for `NA` transition risk score 
   expect_true(is.na(unique(output$transition_risk_score)))
   # `transition_risk_category` is `NA` for `NA` transition risk score
   expect_true(is.na(unique(output$transition_risk_category)))
-})
-
-test_that("outputs columns `transition_risk_category_share` and `transition_risk_category` at company level", {
-  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
-  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
-  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_europages_companies <- read_csv(toy_europages_companies())
-  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
-  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
-  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
-  toy_isic_name <- read_csv(toy_isic_name())
-  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-
-  toy_emissions_profile <- profile_emissions(
-    companies = toy_emissions_profile_any_companies,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-  toy_sector_profile <- profile_sector(
-    companies = toy_sector_profile_companies,
-    scenarios = toy_sector_profile_any_scenarios,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-
-  company_level_output <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
-  ) |>
-    unnest_company()
-
-  expected_cols <- c("transition_risk_category_share", "transition_risk_category")
-
-  expect_true(all(unique(expected_cols) %in% names(company_level_output)))
 })
 
 test_that("outputs `NA` in `avg_transition_risk_best_case` and `avg_transition_risk_worst_case` for `NA` at company level if `transition_risk_score` and `transition_risk_category` are `NA` at product level", {
@@ -179,8 +130,7 @@ test_that("outputs `NA` in `avg_transition_risk_best_case` and `avg_transition_r
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
+    scenarios = toy_sector_profile_any_scenarios
   )
 
   product_level_output <- output |>
@@ -197,94 +147,7 @@ test_that("outputs `NA` in `avg_transition_risk_best_case` and `avg_transition_r
   expect_true(is.na(unique(company_level_output$avg_transition_risk_worst_case)))
 })
 
-test_that("is sensitive to `pivot_wider`", {
-  withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
-
-  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
-    filter(activity_uuid_product_uuid != "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
-  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
-  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_europages_companies <- read_csv(toy_europages_companies())
-  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
-  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
-  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
-  toy_isic_name <- read_csv(toy_isic_name())
-  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-
-  toy_emissions_profile <- profile_emissions(
-    companies = toy_emissions_profile_any_companies,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-  toy_sector_profile <- profile_sector(
-    companies = toy_sector_profile_companies,
-    scenarios = toy_sector_profile_any_scenarios,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-
-  long <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios
-  )
-
-  wide <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE
-  )
-
-  expect_equal(names(long), names(wide))
-
-  #Emissions profile
-  long_emission_cols <- long |>
-    unnest_company() |>
-    select(matches("emission")) |>
-    ncol()
-  wide_emission_cols <- wide |>
-    unnest_company() |>
-    select(matches("emission")) |>
-    ncol()
-  expect_true(long_emission_cols < wide_emission_cols)
-
-  #Sector profile
-  long_sector_cols <- long |>
-    unnest_company() |>
-    select(matches("sector")) |>
-    ncol()
-  wide_sector_cols <- wide |>
-    unnest_company() |>
-    select(matches("sector")) |>
-    ncol()
-  expect_true(long_sector_cols < wide_sector_cols)
-
-  #Transition risk profile
-  long_transition_risk_cols <- long |>
-    unnest_company() |>
-    select(matches("transition_risk")) |>
-    ncol()
-  wide_transition_risk_cols <- wide |>
-    unnest_company() |>
-    select(matches("transition_risk")) |>
-    ncol()
-  expect_true(long_transition_risk_cols < wide_transition_risk_cols)
-})
-
-test_that("with `*.output_co2_footprint` unset, `pivot_wider = TRUE` and `for_webtool = TRUE` yields no error", {
+test_that("with `*.output_co2_footprint` unset, `for_webtool = TRUE` yields no error", {
   unset <- NULL
   withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = unset))
 
@@ -326,7 +189,6 @@ test_that("with `*.output_co2_footprint` unset, `pivot_wider = TRUE` and `for_we
       co2 = toy_emissions_profile_products_ecoinvent,
       all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
       scenarios = toy_sector_profile_any_scenarios,
-      pivot_wider = TRUE,
       for_webtool = TRUE
     )
   )
@@ -367,7 +229,7 @@ test_that("doesn't output `co2_footprint` at product level and `co2e_avg` at com
     isic = toy_isic_name
   )
 
-  long <- transition_risk_profile(
+  output <- transition_risk_profile(
     emissions_profile = toy_emissions_profile,
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
@@ -376,20 +238,8 @@ test_that("doesn't output `co2_footprint` at product level and `co2e_avg` at com
     for_webtool = TRUE
   )
 
-  wide <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE,
-    for_webtool = TRUE
-  )
-
-  expect_false("co2_footprint" %in% names(unnest_product(long)))
-  expect_false("co2e_avg" %in% names(unnest_company(long)))
-  expect_false("co2_footprint" %in% names(unnest_product(wide)))
-  expect_false("co2e_avg" %in% names(unnest_company(wide)))
+  expect_false("co2_footprint" %in% names(unnest_product(output)))
+  expect_false("co2e_avg" %in% names(unnest_company(output)))
 })
 
 
@@ -427,7 +277,7 @@ test_that("outputs `co2_footprint` at product level and `co2e_avg` at company le
     isic = toy_isic_name
   )
 
-  long <- transition_risk_profile(
+  output <- transition_risk_profile(
     emissions_profile = toy_emissions_profile,
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
@@ -435,19 +285,8 @@ test_that("outputs `co2_footprint` at product level and `co2e_avg` at company le
     scenarios = toy_sector_profile_any_scenarios
   )
 
-  wide <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE
-  )
-
-  expect_true("co2_footprint" %in% names(unnest_product(long)))
-  expect_true("co2e_avg" %in% names(unnest_company(long)))
-  expect_true("co2_footprint" %in% names(unnest_product(wide)))
-  expect_true("co2e_avg" %in% names(unnest_company(wide)))
+  expect_true("co2_footprint" %in% names(unnest_product(output)))
+  expect_true("co2e_avg" %in% names(unnest_company(output)))
 })
 
 test_that("removes `co2_footprint` at product level and `co2e_avg` at company level if `*.output_co2_footprint = TRUE` and `for_webtool = TRUE`", {
@@ -484,22 +323,21 @@ test_that("removes `co2_footprint` at product level and `co2e_avg` at company le
     isic = toy_isic_name
   )
 
-  wide <- transition_risk_profile(
+  output <- transition_risk_profile(
     emissions_profile = toy_emissions_profile,
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
     scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE,
     for_webtool = TRUE
   )
 
-  expect_true(!("co2_footprint" %in% names(unnest_product(wide))))
-  expect_true(!("co2e_avg" %in% names(unnest_company(wide))))
+  expect_true(!("co2_footprint" %in% names(unnest_product(output))))
+  expect_true(!("co2e_avg" %in% names(unnest_company(output))))
 })
 
 
-test_that("with `pivot_wider = TRUE`, at company level the `emission*` column are of type double", {
+test_that("At company level the `emission*` column are of type double", {
   withr::local_options(list(tiltIndicatorAfter.output_co2_footprint = TRUE))
 
   toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
@@ -538,8 +376,7 @@ test_that("with `pivot_wider = TRUE`, at company level the `emission*` column ar
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE
+    scenarios = toy_sector_profile_any_scenarios
   ) |>
     unnest_company() |>
     select(matches("emission_")) |>
@@ -586,8 +423,7 @@ test_that("the output at product level has all the new required columns (#189)",
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
+    scenarios = toy_sector_profile_any_scenarios
   ) |>
     unnest_product()
 
@@ -643,8 +479,7 @@ test_that("the output at company level has has all the new required columns (#18
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE
+    scenarios = toy_sector_profile_any_scenarios
   ) |>
     unnest_company()
 
@@ -699,8 +534,7 @@ test_that("At product level, when either `sector_category` is NA or `emission_ca
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE
+    scenarios = toy_sector_profile_any_scenarios
   ) |> unnest_product()
 
   # when `sector_category` is NA then, tilt and isic sectors are not NA
@@ -753,8 +587,7 @@ test_that("`transition_risk_NA_share` is not NA for all cases of benchmark combi
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
+    scenarios = toy_sector_profile_any_scenarios
   )
 
   output_product <- output |> unnest_product()
@@ -802,8 +635,7 @@ test_that("`transition_risk_NA_share` is not greater than 1 and not less than 0 
     sector_profile = toy_sector_profile,
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE
+    scenarios = toy_sector_profile_any_scenarios
   )
 
   output_product <- output |> unnest_product()
@@ -855,7 +687,6 @@ test_that("is sensitive to `for_webtool`", {
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
     scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE,
     for_webtool = FALSE
   )
 
@@ -865,7 +696,6 @@ test_that("is sensitive to `for_webtool`", {
     co2 = toy_emissions_profile_products_ecoinvent,
     all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
     scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE,
     for_webtool = TRUE
   )
 
@@ -878,71 +708,6 @@ test_that("is sensitive to `for_webtool`", {
     unnest_company() |>
     ncol()
   expect_true(for_webtool_company < not_for_webtool_company)
-})
-
-test_that("we can't have webtool output if `pivot_wider = FALSE` and `for_webtool = TRUE`", {
-  toy_emissions_profile_products_ecoinvent <- read_csv(toy_emissions_profile_products_ecoinvent()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_emissions_profile_any_companies <- read_csv(toy_emissions_profile_any_companies())
-  toy_sector_profile_any_scenarios <- read_csv(toy_sector_profile_any_scenarios())
-  toy_sector_profile_companies <- read_csv(toy_sector_profile_companies()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-  toy_europages_companies <- read_csv(toy_europages_companies())
-  toy_ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
-  toy_ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
-  toy_ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
-  toy_isic_name <- read_csv(toy_isic_name())
-  toy_all_activities_scenario_sectors <- read_csv(toy_all_activities_scenario_sectors()) |>
-    filter(activity_uuid_product_uuid == "76269c17-78d6-420b-991a-aa38c51b45b7")
-
-  toy_emissions_profile <- profile_emissions(
-    companies = toy_emissions_profile_any_companies,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-  toy_sector_profile <- profile_sector(
-    companies = toy_sector_profile_companies,
-    scenarios = toy_sector_profile_any_scenarios,
-    europages_companies = toy_europages_companies,
-    ecoinvent_activities = toy_ecoinvent_activities,
-    ecoinvent_europages = toy_ecoinvent_europages,
-    isic = toy_isic_name
-  )
-
-  for_webtool <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = TRUE,
-    for_webtool = TRUE
-  )
-
-  for_webtool_test <- transition_risk_profile(
-    emissions_profile = toy_emissions_profile,
-    sector_profile = toy_sector_profile,
-    co2 = toy_emissions_profile_products_ecoinvent,
-    all_activities_scenario_sectors = toy_all_activities_scenario_sectors,
-    scenarios = toy_sector_profile_any_scenarios,
-    pivot_wider = FALSE,
-    for_webtool = TRUE
-  )
-
-  expect_equal(names(for_webtool), names(for_webtool_test))
-
-  # `for_webtool_test` doesn't provide webtool output because it doesn't give same
-  # number of columns at company level as `for_webtool`.
-  for_webtool_company <- for_webtool |>
-    unnest_company() |>
-    ncol()
-  for_webtool_test_company <- for_webtool_test |>
-    unnest_company() |>
-    ncol()
-  expect_false(for_webtool_company == for_webtool_test_company)
 })
 
 test_that("case 3 companies are identified correctly", {


### PR DESCRIPTION
* closes #301 

Dear,

This PR removes the `long-format` and keep only the `wide-format` option for the company-level output columns. It's an old requirement which will be deleted, and hence no testing is required. 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
